### PR TITLE
build: :hammer: exclude listing TODO tags in `justfile`

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ run-all: install-deps update-quarto-theme format-python _checks _tests _builds
 
 # List all TODO items in the repository
 list-todos:
-  grep -R -n --exclude="*.code-snippets" "TODO" *
+  grep -R -n --exclude="*.code-snippets" --exclude="justfile" "TODO" *
 
 # Install the pre-commit hooks
 install-precommit:


### PR DESCRIPTION
# Description

There will always be at least two TODOs there, so just exclude it.

This PR needs a quick review.
