### PR TITLE
feat: :sparkles: add `Config`, `Rule`, `Exclude`

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -64,15 +64,11 @@ quartodoc:
   options: null
   sections:
   - title: check_datapackage
-    desc: Check functions and constants for the Frictionless Data Package standard.
+    desc: Classes and functions in `check_datapackage`.
     contents:
-    - name: CheckError
-    - name: CheckErrorMatcher
-    # TODO: fix how constants are rendered by quartodoc
-    # - name: constants.PACKAGE_RECOMMENDED_FIELDS
-    # - name: constants.PACKAGE_REQUIRED_FIELDS
-    # - name: constants.RESOURCE_REQUIRED_FIELDS
-    - name: RequiredFieldType
+    - name: Config
+    - name: Exclude
+    - name: Rule
 
 metadata-files:
   - docs/reference/_sidebar.yml

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -158,76 +158,19 @@ be useful for a CLI interface.
 `Config` is a class that holds all the configurations for the `check()`
 function.
 
-``` python
-@dataclass
-class Config:
-    """Configuration for checking a Data Package descriptor.
-
-    Attributes:
-        exclude (list[Exclude]): Any issues matching any of these exclusions will be
-            ignored (i.e., removed from the output of the check function).
-        rules (list[Rule]): Custom checks listed here will be done in addition
-            to checks defined in the Data Package standard.
-        version (str): Version(s) of the Data Package standard to check against.
-            Defaults to "v2".
-        strict (bool): Whether to run recommended as well as required checks. If
-            True, recommended checks will also be run. Default is False.
-    """
-    exclude: list[Exclude] = []
-    rules: list[Rule] = []
-    version: str = "v2"
-    strict: bool = False
-```
+See the help documentation with `help(Config)` for more details.
 
 ### {{< var wip >}} `Exclude`
 
 A subitem of `Config` for expressing checks to ignore.
 
-``` python
-@dataclass
-class Exclude:
-    """Exclude specific checks when checking a Data Package descriptor.
-
-    Attributes:
-        target (str): [JSON path](https://en.wikipedia.org/wiki/JSONPath)
-            to the field or fields in the input object where errors should be ignored,
-            e.g., `$.resources[*].name`. Needs to point to the location in the descriptor
-            of the error to ignore.
-        type (str | None): The type of the check to ignore (e.g., "required" or
-            "pattern").  If not provided, all types of checks will be ignored for
-            the given target.
-    """
-    target: str
-    type: str | None = None
-```
+See the help documentation with `help(Exclude)` for more details.
 
 #### {{< var wip >}} `Rule`
 
 Expresses a custom check.
 
-``` python
-@dataclass
-class Rule:
-    """A custom check to be done on a Data Package descriptor.
-
-    Attributes:
-        target (str): [JSON path](https://en.wikipedia.org/wiki/JSONPath)
-            to the field or fields in the input object where the rule should be used,
-            e.g., `$.resources[*].name`. Needs to point to the location in the descriptor
-            for the rule to apply to.
-        type (str): The type of the check defined by the rule. Can be a type that
-            exists in the Data Package standard (e.g., "required" or "pattern") or a
-            custom type.
-        message (str): A user-friendly explanation of what went wrong and any
-            tips for fixing it.
-        check (Callable[[Any], bool]): Function for doing the custom check. Takes a
-            value and returns true if the check passes, false if it fails.
-    """
-    target: str
-    message: str
-    check: Callable[[Any], bool]
-    type: str = "custom"
-```
+See the help documentation with `help(Rule)` for more details.
 
 ### {{< var wip >}} `Issue`
 

--- a/src/check_datapackage/__init__.py
+++ b/src/check_datapackage/__init__.py
@@ -5,15 +5,21 @@ from .check_error_matcher import CheckErrorMatcher
 from .check_package_properties import check_package_properties
 from .check_properties import check_properties
 from .check_resource_properties import check_resource_properties
+from .config import Config
 from .constants import (
     PACKAGE_RECOMMENDED_FIELDS,
     PACKAGE_REQUIRED_FIELDS,
     RESOURCE_REQUIRED_FIELDS,
     RequiredFieldType,
 )
+from .exclude import Exclude
 from .exclude_matching_errors import exclude_matching_errors
+from .rule import Rule
 
 __all__ = [
+    "Config",
+    "Exclude",
+    "Rule",
     "CheckError",
     "CheckErrorMatcher",
     "check_properties",

--- a/src/check_datapackage/config.py
+++ b/src/check_datapackage/config.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass, field
+from typing import Literal
+
+from check_datapackage.exclude import Exclude
+from check_datapackage.rule import Rule
+
+
+@dataclass
+class Config:
+    """Configuration for checking a Data Package descriptor.
+
+    Attributes:
+        exclude (list[Exclude]): Any issues matching any of these exclusions will be
+            ignored (i.e., removed from the output of the check function).
+        rules (list[Rule]): Custom checks listed here will be done in addition
+            to checks defined in the Data Package standard.
+        strict (bool): Whether to run recommended as well as required checks. If
+            True, recommended checks will also be run. Defaults to False.
+        version (str): The version of the Data Package standard to check against.
+            Defaults to "v2".
+
+    Examples:
+        ```{python}
+        import check_datapackage as cdp
+
+        exclude_required = cdp.Exclude(type="required")
+        license_rule = cdp.Rule(
+            type="only-mit",
+            target="$.licenses[*].name",
+            message="Data Packages may only be licensed under MIT.",
+            check=lambda license_name: license_name == "mit",
+        )
+        config = cdp.Config(exclude=[exclude_required], rules=[license_rule])
+        ```
+    """
+
+    exclude: list[Exclude] = field(default_factory=list)
+    rules: list[Rule] = field(default_factory=list)
+    strict: bool = False
+    version: Literal["v1", "v2"] = "v2"

--- a/src/check_datapackage/exclude.py
+++ b/src/check_datapackage/exclude.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Exclude:
+    """Exclude issues when checking a Data Package descriptor.
+
+    When both `target` and `type` are provided, an issue has to match both to be
+    excluded.
+
+    Attributes:
+        target (str | None): [JSON path](https://jg-rp.github.io/python-jsonpath/syntax/)
+            to the field or fields in the input object where issues should be ignored,
+            e.g., `$.resources[*].name`. Needs to point to the location in the
+            descriptor of the issue to ignore. If not provided, issues of the given
+            `type` will be excluded for all fields.
+        type (str | None): The type of the issue to ignore (e.g., "required" or
+            "pattern").  If not provided, all types of issues will be ignored for
+            the given `target`.
+
+    Examples:
+        ```{python}
+        import check_datapackage as cdp
+
+        exclude_required = cdp.Exclude(type="required")
+        exclude_name = cdp.Exclude(target="$.name")
+        exclude_desc_required = cdp.Exclude(
+            type="required", target="$.resources[*].description"
+        )
+        ```
+    """
+
+    target: str | None = None
+    type: str | None = None

--- a/src/check_datapackage/rule.py
+++ b/src/check_datapackage/rule.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass
+class Rule:
+    """A custom check to be done on a Data Package descriptor.
+
+    Attributes:
+        target (str): The location of the field or fields, expressed in [JSON
+            path](https://jg-rp.github.io/python-jsonpath/syntax/) notation, to which
+            the rule applies (e.g., `$.resources[*].name`).
+        message (str): The message that is shown when the rule is violated.
+        check (Callable[[Any], bool]): A function that expresses how compliance with the
+            rule is checked. It takes the value at the `target` location as input and
+            returns true if the rule is met, false if it isn't.
+        type (str): An identifier for your rule. This is what will show up in
+            error messages and what you will use if you want to exclude your
+            rule. Each `Rule` should have a unique `type`.
+
+    Examples:
+        ```{python}
+        import check_datapackage as cdp
+
+        license_rule = cdp.Rule(
+            type="only-mit",
+            target="$.licenses[*].name",
+            message="Data Packages may only be licensed under MIT.",
+            check=lambda license_name: license_name == "mit",
+        )
+        ```
+    """
+
+    target: str
+    message: str
+    check: Callable[[Any], bool]
+    type: str = "custom"

--- a/src/check_datapackage/rule.py
+++ b/src/check_datapackage/rule.py
@@ -14,9 +14,8 @@ class Rule:
         check (Callable[[Any], bool]): A function that expresses how compliance with the
             rule is checked. It takes the value at the `target` location as input and
             returns true if the rule is met, false if it isn't.
-        type (str): An identifier for your rule. This is what will show up in
-            error messages and what you will use if you want to exclude your
-            rule. Each `Rule` should have a unique `type`.
+        type (str): An identifier for the rule. It will be shown in error messages and
+            can be used to exclude the rule. Each rule should have a unique `type`.
 
     Examples:
         ```{python}

--- a/tools/vulture-allowlist.py
+++ b/tools/vulture-allowlist.py
@@ -1,2 +1,9 @@
 # ruff: noqa
 # mypy: ignore-errors
+exclude  # unused variable (src/check_datapackage/config.py:37)
+rules  # unused variable (src/check_datapackage/config.py:38)
+strict  # unused variable (src/check_datapackage/config.py:39)
+version  # unused variable (src/check_datapackage/config.py:40)
+target  # unused variable (src/check_datapackage/exclude.py:33)
+target  # unused variable (src/check_datapackage/rule.py:34)
+check  # unused variable (src/check_datapackage/rule.py:36)


### PR DESCRIPTION
# Description

This PR adds `Config`, `Rule`, and `Exclude`. For now, only the attributes are included.

Closes #42, closes #24

Needs an in-depth review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
