### PR TITLE
feat: :sparkles: add `Issue` class

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -70,6 +70,7 @@ quartodoc:
     - name: Config
     - name: Exclude
     - name: Rule
+    - name: Issue
 
 metadata-files:
   - docs/reference/_sidebar.yml

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -154,7 +154,8 @@ See the help documentation with `help(Rule)` for more details.
 This class represents an issue that is found when checking a Data
 Package.
 
-See the help documentation with [`help(Issue)`](/docs/reference/issue.qmd) for more details.
+See the help documentation with
+[`help(Issue)`](/docs/reference/issue.qmd) for more details.
 
 ## Flow
 

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -152,35 +152,9 @@ See the help documentation with `help(Rule)` for more details.
 ### {{< var wip >}} `Issue`
 
 This class represents an issue that is found when checking a Data
-Package, with the following interface:
+Package.
 
-``` python
-@dataclass
-class Issue:
-    """An issue found while checking a Data Package descriptor
-
-    One Issue object represents one failed check on one field within the descriptor.
-
-    Attributes:
-        location (string): A [JSON path](https://en.wikipedia.org/wiki/JSONPath)
-            format, pointing to the field in the input object where the issue is located.
-            For example, `"$.resources[2].name"`.
-        message (string): A description of what exactly the issue is.
-        type (string): The type of the check that failed.
-            Used mostly for excluding specific types of issues.
-
-    Methods:
-        __str__(): Return a user-friendly, human-readable message of the issue, with more
-            details than the `message` attribute and more context. Used when running
-            `explain()` on the issues.
-    """
-    location: str
-    message: str
-    type: str
-
-    def __str__(self) -> str:
-        """Return a user-friendly, human-readable string representation of the issue."""
-```
+See the help documentation with `help(Issue)` for more details.
 
 ## Flow
 

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -154,7 +154,7 @@ See the help documentation with `help(Rule)` for more details.
 This class represents an issue that is found when checking a Data
 Package.
 
-See the help documentation with `help(Issue)` for more details.
+See the help documentation with [`help(Issue)`](/docs/reference/issue.qmd) for more details.
 
 ## Flow
 

--- a/src/check_datapackage/__init__.py
+++ b/src/check_datapackage/__init__.py
@@ -12,11 +12,13 @@ from .constants import (
 )
 from .exclude import Exclude
 from .exclude_matching_errors import exclude_matching_errors
+from .issue import Issue
 from .rule import Rule
 
 __all__ = [
     "Config",
     "Exclude",
+    "Issue",
     "Rule",
     "CheckError",
     "CheckErrorMatcher",

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from check_datapackage.check_error import CheckError
 from check_datapackage.config import Config
 from check_datapackage.constants import DATA_PACKAGE_SCHEMA_PATH
 from check_datapackage.internals import (
@@ -9,11 +8,12 @@ from check_datapackage.internals import (
     _check_object_against_json_schema,
     _read_json,
 )
+from check_datapackage.issue import Issue
 
 
 def check(
     descriptor: dict[str, Any], config: Config = Config(), error: bool = False
-) -> list[CheckError]:
+) -> list[Issue]:
     """Checks a Data Package descriptor against the Data Package standard.
 
     Args:

--- a/src/check_datapackage/issue.py
+++ b/src/check_datapackage/issue.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Issue:
+    """An issue found while checking a Data Package descriptor.
+
+    One `Issue` object represents one failed check on one field within the descriptor.
+
+    Attributes:
+        location (string): A [JSON path](https://jg-rp.github.io/python-jsonpath/syntax/)
+            format pointing to the field in the input object where the issue is located.
+            For example, `$.resources[2].name`.
+        message (string): A description of what exactly the issue is.
+        type (string): The type of the check that failed. Used mostly for excluding
+            specific types of issues.
+
+    Examples:
+        ```{python}
+        import check_datapackage as cdp
+
+        issue = cdp.Issue(
+            location="$.resources[2].title",
+            message="The `title` field is required but missing at the given location.",
+            type="required",
+        )
+        ```
+    """
+
+    location: str
+    message: str
+    type: str

--- a/src/check_datapackage/issue.py
+++ b/src/check_datapackage/issue.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(order=True, frozen=True)
 class Issue:
     """An issue found while checking a Data Package descriptor.
 
@@ -11,9 +11,9 @@ class Issue:
         location (string): A [JSON path](https://jg-rp.github.io/python-jsonpath/syntax/)
             format pointing to the field in the input object where the issue is located.
             For example, `$.resources[2].name`.
-        message (string): A description of what exactly the issue is.
         type (string): The type of the check that failed. Used mostly for excluding
             specific types of issues.
+        message (string): A description of what exactly the issue is.
 
     Examples:
         ```{python}
@@ -21,12 +21,12 @@ class Issue:
 
         issue = cdp.Issue(
             location="$.resources[2].title",
-            message="The `title` field is required but missing at the given location.",
             type="required",
+            message="The `title` field is required but missing at the given location.",
         )
         ```
     """
 
     location: str
-    message: str
     type: str
+    message: str

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -25,32 +25,32 @@ def test_fails_descriptor_without_resources():
     """Should fail descriptor without resources."""
     descriptor = {"name": "a name with spaces"}
 
-    errors = check(descriptor)
+    issues = check(descriptor)
 
-    assert len(errors) == 1
-    assert errors[0].validator == "required"
-    assert errors[0].json_path == "$.resources"
+    assert len(issues) == 1
+    assert issues[0].type == "required"
+    assert issues[0].location == "$.resources"
 
 
 @mark.parametrize(
-    "resources, json_path, num_errors",
+    "resources, location, num_issues",
     [
         ([], "$.resources", 1),
         ([{}], "$.resources[0].data", 3),
         ([{"name": "a name", "path": "/a/bad/path"}], "$.resources[0].path", 2),
     ],
 )
-def test_fails_descriptor_with_bad_resources(resources, json_path, num_errors):
+def test_fails_descriptor_with_bad_resources(resources, location, num_issues):
     """Should fail descriptor with malformed resources."""
     descriptor = {
         "name": "a name with spaces",
         "resources": resources,
     }
 
-    errors = check(descriptor)
+    issues = check(descriptor)
 
-    assert len(errors) == num_errors
-    assert errors[0].json_path == json_path
+    assert len(issues) == num_issues
+    assert issues[0].location == location
 
 
 def test_fails_descriptor_with_missing_required_fields():
@@ -61,11 +61,11 @@ def test_fails_descriptor_with_missing_required_fields():
         "licenses": [{"title": "my license"}],
     }
 
-    errors = check(descriptor)
+    issues = check(descriptor)
 
-    assert len(errors) == 2
-    assert all(error.validator == "required" for error in errors)
-    assert {error.json_path for error in errors} == {
+    assert len(issues) == 2
+    assert all(issue.type == "required" for issue in issues)
+    assert {issue.location for issue in issues} == {
         "$.licenses[0].name",
         "$.licenses[0].path",
     }
@@ -77,11 +77,11 @@ def test_fails_descriptor_with_bad_type():
         "name": 123,
         "resources": [{"name": "a name", "path": "data.csv"}],
     }
-    errors = check(descriptor)
+    issues = check(descriptor)
 
-    assert len(errors) == 1
-    assert errors[0].validator == "type"
-    assert errors[0].json_path == "$.name"
+    assert len(issues) == 1
+    assert issues[0].type == "type"
+    assert issues[0].location == "$.name"
 
 
 def test_fails_descriptor_with_bad_format():
@@ -92,11 +92,11 @@ def test_fails_descriptor_with_bad_format():
         "homepage": "not a URL",
     }
 
-    errors = check(descriptor)
+    issues = check(descriptor)
 
-    assert len(errors) == 1
-    assert errors[0].validator == "format"
-    assert errors[0].json_path == "$.homepage"
+    assert len(issues) == 1
+    assert issues[0].type == "format"
+    assert issues[0].location == "$.homepage"
 
 
 def test_fails_descriptor_with_pattern_mismatch():
@@ -107,11 +107,11 @@ def test_fails_descriptor_with_pattern_mismatch():
         "contributors": [{"path": "/a/bad/path"}],
     }
 
-    errors = check(descriptor)
+    issues = check(descriptor)
 
-    assert len(errors) == 1
-    assert errors[0].validator == "pattern"
-    assert errors[0].json_path == "$.contributors[0].path"
+    assert len(issues) == 1
+    assert issues[0].type == "pattern"
+    assert issues[0].location == "$.contributors[0].path"
 
 
 # With recommendations
@@ -140,10 +140,10 @@ def test_fails_descriptor_with_missing_required_fields_with_recommendations():
         "resources": [{"name": "a-name-with-no-spaces", "path": "data.csv"}],
     }
 
-    errors = check(descriptor, config=Config(strict=True))
+    issues = check(descriptor, config=Config(strict=True))
 
-    assert len(errors) == 3
-    assert all(error.validator == "required" for error in errors)
+    assert len(issues) == 3
+    assert all(issue.type == "required" for issue in issues)
 
 
 def test_fails_descriptor_violating_recommendations():
@@ -158,10 +158,10 @@ def test_fails_descriptor_violating_recommendations():
         "resources": [{"name": "a name with spaces", "path": "data.csv"}],
     }
 
-    errors = check(descriptor, config=Config(strict=True))
+    issues = check(descriptor, config=Config(strict=True))
 
-    assert len(errors) == 5
-    assert {error.json_path for error in errors} == {
+    assert len(issues) == 5
+    assert {issue.location for issue in issues} == {
         "$.name",
         "$.version",
         "$.contributors[0].title",


### PR DESCRIPTION
# Description

This PR adds the `Issue` class.
I haven't deleted `CheckError` yet because it is used in the current excluding logic still.

Closes #44 closes #54

Needs an in-depth review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
