### PR TITLE
docs: :pencil2: fix contents of `_contributors.yml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,6 @@ The following people have contributed to this project by submitting pull
 requests :tada:
 
 [@lwjohnst86](https://github.com/lwjohnst86),
-[@signekb](https://github.com/signekb),
-[@martonvago](https://github.com/martonvago) The following people have
-contributed to this project by submitting pull requests :tada:
-
-[@lwjohnst86](https://github.com/lwjohnst86),
 [@martonvago](https://github.com/martonvago),
 [@signekb](https://github.com/signekb)
 

--- a/docs/includes/_contributors.qmd
+++ b/docs/includes/_contributors.qmd
@@ -1,3 +1,3 @@
 The following people have contributed to this project by submitting pull requests :tada:
 
- [\@lwjohnst86](https://github.com/lwjohnst86), [\@signekb](https://github.com/signekb), [\@martonvago](https://github.com/martonvago)
+ [\@lwjohnst86](https://github.com/lwjohnst86), [\@martonvago](https://github.com/martonvago), [\@signekb](https://github.com/signekb)


### PR DESCRIPTION
# Description

This was incorrectly generated with `>>` rather than `>` in the justfile. So this fixes that mistake with `_contributors.yml`.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
