### PR TITLE
feat: :sparkles: add example descriptors

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -71,6 +71,8 @@ quartodoc:
     - name: Exclude
     - name: Rule
     - name: Issue
+    - name: example_package_descriptor
+    - name: example_resource_descriptor
 
 metadata-files:
   - docs/reference/_sidebar.yml

--- a/src/check_datapackage/__init__.py
+++ b/src/check_datapackage/__init__.py
@@ -9,6 +9,7 @@ from .constants import (
     RESOURCE_REQUIRED_FIELDS,
     RequiredFieldType,
 )
+from .examples import example_package_descriptor, example_resource_descriptor
 from .exclude import Exclude
 from .issue import Issue
 from .read_json import read_json
@@ -19,6 +20,8 @@ __all__ = [
     "Exclude",
     "Issue",
     "Rule",
+    "example_package_descriptor",
+    "example_resource_descriptor",
     "CheckError",
     "check",
     "PACKAGE_RECOMMENDED_FIELDS",

--- a/src/check_datapackage/examples.py
+++ b/src/check_datapackage/examples.py
@@ -1,0 +1,37 @@
+from textwrap import dedent
+from typing import Any
+
+
+def example_resource_descriptor() -> dict[str, Any]:
+    """Create an example resource descriptor.
+
+    Returns:
+        An example resource descriptor.
+    """
+    return {
+        "name": "woolly-dormice-2015",
+        "title": "Body fat percentage in the hibernating woolly dormouse",
+        "path": "resources/woolly-dormice-2015/data.parquet",
+    }
+
+
+def example_package_descriptor() -> dict[str, Any]:
+    """Create an example package descriptor.
+
+    Returns:
+        An example package descriptor.
+    """
+    return {
+        "name": "woolly-dormice",
+        "title": "Hibernation Physiology of the Woolly Dormouse: A Scoping Review.",
+        "description": dedent("""
+            This scoping review explores the hibernation physiology of the
+            woolly dormouse, drawing on data collected over a 10-year period
+            along the Taurus Mountain range in Turkey.
+            """),
+        "id": "123-abc-123",
+        "created": "2014-05-14T05:00:01+00:00",
+        "version": "1.0.0",
+        "licenses": [{"name": "odc-pddl"}],
+        "resources": [example_resource_descriptor()],
+    }


### PR DESCRIPTION
# Description

Adds example descriptors (just copied from the guide).

Closes #73 

Needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
