### PR TITLE
refactor: :recycle: sort issues and remove duplicates at the very end

### DIFF
--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -38,4 +38,5 @@ def check(
         _add_resource_recommendations(schema)
 
     issues = _check_object_against_json_schema(descriptor, schema)
-    return exclude(issues, config.exclude)
+    issues = exclude(issues, config.exclude)
+    return sorted(set(issues))

--- a/src/check_datapackage/internals.py
+++ b/src/check_datapackage/internals.py
@@ -89,7 +89,7 @@ def _validation_errors_to_issues(
     Returns:
         A list of `Issue`s.
     """
-    issues = [
+    return [
         Issue(
             message=error.message,
             jsonpath=_get_full_json_path_from_error(error),
@@ -98,7 +98,6 @@ def _validation_errors_to_issues(
         for error in _unwrap_errors(list(validation_errors))
         if str(error.validator) not in COMPLEX_VALIDATORS
     ]
-    return sorted(set(issues))
 
 
 def _unwrap_errors(errors: list[ValidationError]) -> list[ValidationError]:


### PR DESCRIPTION
# Description

This PR moves sorting issues and removing duplicates to the end of the processing chain, so it can all be done once.

Needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
