### PR TITLE
refactor: :recycle: move functionals to internals

### DIFF
--- a/src/check_datapackage/exclude.py
+++ b/src/check_datapackage/exclude.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
-from typing import Any, Callable
 
+from check_datapackage.internals import _filter, _map
 from check_datapackage.issue import Issue
 
 
@@ -70,11 +70,3 @@ def _any_matching_types(issue: Issue, excludes: list[Exclude]) -> bool:
 
 def _same_type(issue: Issue, exclude: Exclude) -> bool:
     return exclude.type == issue.type
-
-
-def _filter(x: Any, fn: Callable[[Any], bool]) -> list[Any]:
-    return list(filter(fn, x))
-
-
-def _map(x: Any, fn: Callable[[Any], Any]) -> list[Any]:
-    return list(map(fn, x))

--- a/src/check_datapackage/internals.py
+++ b/src/check_datapackage/internals.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Iterator
+from typing import Any, Callable, Iterable, Iterator, TypeVar
 
 from jsonschema import Draft7Validator, FormatChecker, ValidationError
 
@@ -133,3 +133,15 @@ def _get_full_json_path_from_error(error: ValidationError) -> str:
         if match:
             return f"{error.json_path}.{match.group(1)}"
     return error.json_path
+
+
+In = TypeVar("In")
+Out = TypeVar("Out")
+
+
+def _map(x: Iterable[In], fn: Callable[[In], Out]) -> list[Out]:
+    return list(map(fn, x))
+
+
+def _filter(x: Iterable[In], fn: Callable[[In], bool]) -> list[In]:
+    return list(filter(fn, x))


### PR DESCRIPTION
# Description

This PR moves the functionals to `internals` and finishes up the type hints.


Needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
