### PR TITLE
refactor: :fire: don't expose private constants

### DIFF
--- a/src/check_datapackage/__init__.py
+++ b/src/check_datapackage/__init__.py
@@ -3,12 +3,6 @@
 from .check import check
 from .check_error import CheckError
 from .config import Config
-from .constants import (
-    PACKAGE_RECOMMENDED_FIELDS,
-    PACKAGE_REQUIRED_FIELDS,
-    RESOURCE_REQUIRED_FIELDS,
-    RequiredFieldType,
-)
 from .examples import example_package_descriptor, example_resource_descriptor
 from .exclude import Exclude
 from .issue import Issue
@@ -24,9 +18,5 @@ __all__ = [
     "example_resource_descriptor",
     "CheckError",
     "check",
-    "PACKAGE_RECOMMENDED_FIELDS",
-    "PACKAGE_REQUIRED_FIELDS",
-    "RESOURCE_REQUIRED_FIELDS",
-    "RequiredFieldType",
     "read_json",
 ]

--- a/src/check_datapackage/constants.py
+++ b/src/check_datapackage/constants.py
@@ -26,16 +26,6 @@ PACKAGE_RECOMMENDED_FIELDS = {
     "licenses": RequiredFieldType.list,
 }
 
-PACKAGE_REQUIRED_FIELDS = {
-    "resources": RequiredFieldType.list,
-}
-
-RESOURCE_REQUIRED_FIELDS = {
-    "name": RequiredFieldType.str,
-    "path": RequiredFieldType.str,
-    "data": RequiredFieldType.any,
-}
-
 # From https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 SEMVER_PATTERN = (
     r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"


### PR DESCRIPTION
# Description

These are private so shouldn't be exposed. Some code was only used in the `__init__.py` file, so removing them there made them deadcode, which I removed.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
