### PR TITLE
docs: :wrench: fix ordering of Guide docs

### DIFF
--- a/docs/guide/check.qmd
+++ b/docs/guide/check.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Checking a Data Package descriptor"
 jupyter: python3
+order: 1
 # TODO: eval when implemented
 eval: false
 ---

--- a/docs/guide/config.qmd
+++ b/docs/guide/config.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Configuring the checks"
 jupyter: python3
+order: 3
 # TODO: eval when implemented
 eval: false
 ---

--- a/docs/guide/issues.qmd
+++ b/docs/guide/issues.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Understanding issues"
 jupyter: python3
+order: 2
 # TODO: eval when implemented
 eval: false
 ---


### PR DESCRIPTION
# Description

The guide docs were not in order. This fixes that.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
