### PR TITLE
docs: :memo: update c4 container diagram

### DIFF
--- a/docs/design/architecture.qmd
+++ b/docs/design/architecture.qmd
@@ -102,7 +102,7 @@ flowchart LR
 
 
     dp_standard --"Definition of the standard"--> check
-    Users --"Check the compliance of<br>a Data Package's<br>descriptor"--> check
+    Users --"Check Data Package<br>descriptor"--> check
     %% Styling
     style Users fill:#FFFFFF, color:#000000
 ```
@@ -137,8 +137,8 @@ flowchart LR
     end
 
     dp_standard --"Definition of the standard"--> python
-    users --"Programmatically check<br>the compliance of<br>a Data Package's<br>descriptor"--> python
-    users -. "Check the compliance of<br>a Data Package's<br>descriptor via the<br>command line" .-> cli
+    users --"Check Data Package<br>descriptor programmatically"--> python
+    users -. "Check Data Package<br>descriptor via the CLI" .-> cli
 
     %% Styling
     style check-datapackage fill:#FFFFFF, color:#000000

--- a/docs/design/architecture.qmd
+++ b/docs/design/architecture.qmd
@@ -101,7 +101,7 @@ flowchart LR
     check("check-datapackage<br>[Python package]")
 
 
-    dp_standard --"Definition of the standard<br>and its recommendations"--> check
+    dp_standard --"Definition of the standard"--> check
     Users --"Check the compliance of<br>a Data Package's<br>descriptor"--> check
     %% Styling
     style Users fill:#FFFFFF, color:#000000
@@ -136,7 +136,7 @@ flowchart LR
     python -. "Provides<br>functionality" .-> cli
     end
 
-    dp_standard --"Definition of the standard<br>and its recommendations"--> python
+    dp_standard --"Definition of the standard"--> python
     users --"Programmatically check<br>the compliance of<br>a Data Package's<br>descriptor"--> python
     users -. "Check the compliance of<br>a Data Package's<br>descriptor via the<br>command line" .-> cli
 

--- a/docs/design/architecture.qmd
+++ b/docs/design/architecture.qmd
@@ -111,20 +111,32 @@ flowchart LR
 
 ### Container
 
-The Container diagram shows the larger parts of the system, what they
-are responsible for, and how they interact with each other. It also
-shows the technology choices for each container.
+In C4, a [container diagram](https://c4model.com/diagrams/container) zooms in on the system boundary to show the
+*containers* within it, such as web applications or databases. This diagram displays the main containers of `check-datapackage`, their
+responsibilities, and how they interact, including the technologies used for each.
+
+Currently, we build `check-datapackage` with a single container---the core Python package---but we've designed it to be extendable as a command line interface (CLI) in the future. With a CLI, we want to ease the process of implementing the checks in e.g., continuous integration pipelines.
 
 ```{mermaid}
 %%| label: fig-c4-container
-%%| fig-cap: "C4 Container diagram showing larger parts of `check-datapackage` and their connections."
+%%| fig-cap: "C4 container diagram showing the core Python package in `check-datapackage` and the future command line interface (displayed dashed)."
 flowchart LR
-    ext_dp_schema(["Data Package standard<br>[JSON]<br><br>Define descriptor<br>structure and contents."])
-    in_dp_json(["Descriptor<br>[Python]<br><br>Describe Data Package<br>or Data Resource."])
-    config(["Config<br>[Python]<br><br>Configure check<br>behaviour and output."])
-    check
 
-    config --> check
-    ext_dp_schema --> check
-    in_dp_json --> check
+    users("Users<br>[person]")
+    dp_standard("Data Package V2<br>[standard]")
+
+    subgraph "check-datapackage"
+        python("Core Python Package<br>[Python, JSON schema]")
+        cli("CLI<br>[TBD technology]")
+
+    python -. "Provides<br>functionality" .-> cli
+    end
+
+    dp_standard --"Definition of the standard<br>and its recommendations"--> python
+    users --"Programmatically check<br>the compliance of<br>a Data Package's<br>descriptor"--> python
+    users -. "Check the compliance of<br>a Data Package's<br>descriptor via the<br>command line" .-> cli
+
+    %% Styling
+    style check-datapackage fill:#FFFFFF, color:#000000
+    style cli fill:#FFFFFF, stroke-dasharray: 5 5
 ```

--- a/docs/design/architecture.qmd
+++ b/docs/design/architecture.qmd
@@ -131,7 +131,7 @@ flowchart LR
 
     subgraph "check-datapackage"
         python("Core Python Package<br>[Python, JSON schema]")
-        cli("CLI<br>[TBD technology]")
+        cli("CLI<br>[Python]")
 
     python -. "Provides<br>functionality" .-> cli
     end

--- a/docs/design/architecture.qmd
+++ b/docs/design/architecture.qmd
@@ -102,8 +102,7 @@ flowchart LR
 
 
     dp_standard --"Definition of the standard<br>and its recommendations"--> check
-    Users --"Checks the compliance of<br>their Data Package's<br>descriptor"--> check
-
+    Users --"Check the compliance of<br>a Data Package's<br>descriptor"--> check
     %% Styling
     style Users fill:#FFFFFF, color:#000000
 ```

--- a/docs/design/architecture.qmd
+++ b/docs/design/architecture.qmd
@@ -107,14 +107,19 @@ flowchart LR
     style Users fill:#FFFFFF, color:#000000
 ```
 
-
 ### Container
 
-In C4, a [container diagram](https://c4model.com/diagrams/container) zooms in on the system boundary to show the
-*containers* within it, such as web applications or databases. This diagram displays the main containers of `check-datapackage`, their
-responsibilities, and how they interact, including the technologies used for each.
+In C4, a [container diagram](https://c4model.com/diagrams/container)
+zooms in on the system boundary to show the *containers* within it, such
+as web applications or databases. This diagram displays the main
+containers of `check-datapackage`, their responsibilities, and how they
+interact, including the technologies used for each.
 
-Currently, we build `check-datapackage` with a single container---the core Python package---but we've designed it to be extendable as a command line interface (CLI) in the future. With a CLI, we want to ease the process of implementing the checks in e.g., continuous integration pipelines.
+Currently, we build `check-datapackage` with a single container---the
+core Python package---but we've designed it to be extendable as a
+command line interface (CLI) in the future. With a CLI, we want to ease
+the process of implementing the checks in e.g., continuous integration
+pipelines.
 
 ```{mermaid}
 %%| label: fig-c4-container


### PR DESCRIPTION
# Description

I've updated the C4 container diagram so the containers are the core Python package and a future CLI.
I've also updated the text explaining what a container diagram is. 

Related to #46 

Needs an in-depth review.

## Checklist

- [X] Formatted Markdown
- [X] Ran `just run-all`
