### PR TITLE
fix: :bug: filter out path and data errors correctly

### DIFF
--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -143,13 +143,15 @@ def _handle_S_resources_x(
 ) -> list[SchemaError]:
     """Do not flag missing `path` and `data` separately."""
     errors_in_group = _filter(schema_errors, lambda error: error.parent == parent_error)
+    # If the parent error is caused by other errors, remove it
+    if errors_in_group:
+        schema_errors.remove(parent_error)
+
     path_or_data_required_errors = _filter(
         errors_in_group, _path_or_data_required_error
     )
-
     # If path and data are both missing, add a more informative error
-    if path_or_data_required_errors:
-        schema_errors.remove(parent_error)
+    if len(path_or_data_required_errors) > 1:
         schema_errors.append(
             SchemaError(
                 message=(
@@ -162,7 +164,7 @@ def _handle_S_resources_x(
             )
         )
 
-    # Remove all original required errors on $.resources[x].path and $.resources[x].data
+    # Remove all required errors on path and data
     return _filter(
         schema_errors, lambda error: error not in path_or_data_required_errors
     )

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -191,6 +191,17 @@ def test_fail_with_resource_name_path_and_data_missing():
     assert issues[1].type == "required"
 
 
+def test_fail_with_only_resource_name_missing():
+    descriptor = example_package_descriptor()
+    del descriptor["resources"][0]["name"]
+
+    issues = check(descriptor)
+
+    assert len(issues) == 1
+    assert issues[0].jsonpath == "$.resources[0].name"
+    assert issues[0].type == "required"
+
+
 def test_fail_with_multiple_resources():
     descriptor = example_package_descriptor()
     descriptor["resources"].append(example_resource_descriptor())


### PR DESCRIPTION
# Description

I refactored this wrong, sorry, fixing it here.

Needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
