### PR TITLE
refactor: ♻️  rename example dicts from "descriptor" to "properties"

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -71,8 +71,8 @@ quartodoc:
     - name: CustomCheck
     - name: Exclude
     - name: Issue
-    - name: example_package_descriptor
-    - name: example_resource_descriptor
+    - name: example_package_properties
+    - name: example_resource_properties
 
 metadata-files:
   - docs/reference/_sidebar.yml

--- a/src/check_datapackage/__init__.py
+++ b/src/check_datapackage/__init__.py
@@ -3,7 +3,7 @@
 from .check import check
 from .config import Config
 from .custom_check import CustomCheck
-from .examples import example_package_descriptor, example_resource_descriptor
+from .examples import example_package_properties, example_resource_properties
 from .exclude import Exclude
 from .issue import Issue
 from .read_json import read_json
@@ -13,8 +13,8 @@ __all__ = [
     "Exclude",
     "Issue",
     "CustomCheck",
-    "example_package_descriptor",
-    "example_resource_descriptor",
+    "example_package_properties",
+    "example_resource_properties",
     "check",
     "read_json",
 ]

--- a/src/check_datapackage/examples.py
+++ b/src/check_datapackage/examples.py
@@ -2,11 +2,11 @@ from textwrap import dedent
 from typing import Any
 
 
-def example_resource_descriptor() -> dict[str, Any]:
-    """Create an example resource descriptor.
+def example_resource_properties() -> dict[str, Any]:
+    """Create an example resource properties.
 
     Returns:
-        An example resource descriptor.
+        An example resource properties.
     """
     return {
         "name": "woolly-dormice-2015",
@@ -15,11 +15,11 @@ def example_resource_descriptor() -> dict[str, Any]:
     }
 
 
-def example_package_descriptor() -> dict[str, Any]:
-    """Create an example package descriptor.
+def example_package_properties() -> dict[str, Any]:
+    """Create an example package properties.
 
     Returns:
-        An example package descriptor.
+        An example package properties.
     """
     return {
         "name": "woolly-dormice",
@@ -33,5 +33,5 @@ def example_package_descriptor() -> dict[str, Any]:
         "created": "2014-05-14T05:00:01+00:00",
         "version": "1.0.0",
         "licenses": [{"name": "odc-pddl"}],
-        "resources": [example_resource_descriptor()],
+        "resources": [example_resource_properties()],
     }

--- a/src/check_datapackage/examples.py
+++ b/src/check_datapackage/examples.py
@@ -3,10 +3,10 @@ from typing import Any
 
 
 def example_resource_properties() -> dict[str, Any]:
-    """Create an example resource properties.
+    """Create a set of example resource properties.
 
     Returns:
-        An example resource properties.
+        A set of example resource properties.
     """
     return {
         "name": "woolly-dormice-2015",
@@ -16,10 +16,10 @@ def example_resource_properties() -> dict[str, Any]:
 
 
 def example_package_properties() -> dict[str, Any]:
-    """Create an example package properties.
+    """Create a set of example package properties.
 
     Returns:
-        An example package properties.
+        A set of example package properties.
     """
     return {
         "name": "woolly-dormice",

--- a/tests/test_custom_check.py
+++ b/tests/test_custom_check.py
@@ -2,8 +2,8 @@ from check_datapackage.check import check
 from check_datapackage.config import Config
 from check_datapackage.custom_check import CustomCheck
 from check_datapackage.examples import (
-    example_package_descriptor,
-    example_resource_descriptor,
+    example_package_properties,
+    example_resource_properties,
 )
 from check_datapackage.issue import Issue
 
@@ -22,10 +22,10 @@ resource_name_check = CustomCheck(
 
 
 def test_direct_jsonpath():
-    descriptor = example_package_descriptor()
-    descriptor["name"] = "ALLCAPS"
+    properties = example_package_properties()
+    properties["name"] = "ALLCAPS"
     config = Config(custom_checks=[lowercase_check])
-    issues = check(descriptor, config=config)
+    issues = check(properties, config=config)
 
     assert issues == [
         Issue(
@@ -37,12 +37,12 @@ def test_direct_jsonpath():
 
 
 def test_indirect_jsonpath():
-    descriptor = example_package_descriptor()
-    descriptor["resources"].append(example_resource_descriptor())
-    descriptor["resources"][1]["name"] = "not starting with woolly"
+    properties = example_package_properties()
+    properties["resources"].append(example_resource_properties())
+    properties["resources"][1]["name"] = "not starting with woolly"
 
     config = Config(custom_checks=[resource_name_check])
-    issues = check(descriptor, config=config)
+    issues = check(properties, config=config)
 
     assert issues == [
         Issue(
@@ -54,12 +54,12 @@ def test_indirect_jsonpath():
 
 
 def test_multiple_custom_checks():
-    descriptor = example_package_descriptor()
-    descriptor["name"] = "ALLCAPS"
-    descriptor["resources"][0]["name"] = "not starting with woolly"
+    properties = example_package_properties()
+    properties["name"] = "ALLCAPS"
+    properties["resources"][0]["name"] = "not starting with woolly"
 
     config = Config(custom_checks=[lowercase_check, resource_name_check])
-    issues = check(descriptor, config=config)
+    issues = check(properties, config=config)
 
     assert issues == [
         Issue(
@@ -76,17 +76,17 @@ def test_multiple_custom_checks():
 
 
 def test_custom_checks_and_default_checks():
-    descriptor = example_package_descriptor()
-    descriptor["name"] = "ALLCAPS"
-    del descriptor["resources"]
+    properties = example_package_properties()
+    properties["name"] = "ALLCAPS"
+    del properties["resources"]
     config = Config(custom_checks=[lowercase_check])
-    issues = check(descriptor, config=config)
+    issues = check(properties, config=config)
 
     assert [issue.type for issue in issues] == ["lowercase", "required"]
 
 
 def test_no_matching_jsonpath():
-    descriptor = example_package_descriptor()
+    properties = example_package_properties()
     custom_check = CustomCheck(
         jsonpath="$.missing",
         message="This check always fails.",
@@ -94,6 +94,6 @@ def test_no_matching_jsonpath():
         type="always-fail",
     )
     config = Config(custom_checks=[custom_check])
-    issues = check(descriptor, config=config)
+    issues = check(properties, config=config)
 
     assert issues == []

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -4,12 +4,12 @@ from pytest import mark
 
 from check_datapackage.check import check
 from check_datapackage.config import Config
-from check_datapackage.examples import example_package_descriptor
+from check_datapackage.examples import example_package_properties
 from check_datapackage.exclude import Exclude
 
 
 def test_exclude_none_type():
-    descriptor: dict[str, Any] = {
+    properties: dict[str, Any] = {
         "name": "a name",
         "resources": [{"name": "a name", "path": "data.csv"}],
         "contributors": [{"path": "/a/bad/path"}],
@@ -17,18 +17,18 @@ def test_exclude_none_type():
 
     exclude = [Exclude()]
     config = Config(exclude=exclude)
-    issues = check(descriptor, config=config)
+    issues = check(properties, config=config)
 
     assert len(issues) == 1
 
 
 def test_exclude_required_type():
     """Exclude type with the required value."""
-    descriptor = {"name": "a name with spaces"}
+    properties = {"name": "a name with spaces"}
 
     exclude = [Exclude(type="required")]
     config = Config(exclude=exclude)
-    issues = check(descriptor, config=config)
+    issues = check(properties, config=config)
 
     assert len(issues) == 0
 
@@ -36,11 +36,11 @@ def test_exclude_required_type():
 def test_exclude_format_type():
     """Exclude type with the format value."""
     # created must match a date format
-    descriptor = {"created": "20240614"}
+    properties = {"created": "20240614"}
 
     exclude = [Exclude(type="format")]
     config = Config(exclude=exclude)
-    issues = check(descriptor, config=config)
+    issues = check(properties, config=config)
 
     # One issue: missing resources
     assert len(issues) == 1
@@ -48,7 +48,7 @@ def test_exclude_format_type():
 
 def test_exclude_pattern_type():
     """Exclude types with the pattern value."""
-    descriptor: dict[str, Any] = {
+    properties: dict[str, Any] = {
         "name": "a name",
         "resources": [{"name": "a name", "path": "data.csv"}],
         "contributors": [{"path": "/a/bad/path"}],
@@ -56,14 +56,14 @@ def test_exclude_pattern_type():
 
     exclude = [Exclude(type="pattern")]
     config = Config(exclude=exclude)
-    issues = check(descriptor, config=config)
+    issues = check(properties, config=config)
 
     assert len(issues) == 0
 
 
 def test_exclude_multiple_types():
     """Exclude by many types."""
-    descriptor: dict[str, Any] = {
+    properties: dict[str, Any] = {
         "name": "a name",
         "created": "20240614",
         "contributors": [{"path": "/a/bad/path"}],
@@ -75,7 +75,7 @@ def test_exclude_multiple_types():
         Exclude(type="format"),
     ]
     config = Config(exclude=exclude)
-    issues = check(descriptor, config=config)
+    issues = check(properties, config=config)
 
     assert len(issues) == 0
 
@@ -102,60 +102,60 @@ def test_exclude_multiple_types():
     ],
 )
 def test_exclude_jsonpath(jsonpath: str, num_issues: int) -> None:
-    descriptor = example_package_descriptor()
+    properties = example_package_properties()
     # Total 3 issues
-    descriptor["created"] = "20240614"
+    properties["created"] = "20240614"
     # Two issues for resources: type and pattern
-    descriptor["resources"][0]["path"] = "/a/bad/path"
-    descriptor.update({"contributors": [{"path": "/a/bad/path"}]})
+    properties["resources"][0]["path"] = "/a/bad/path"
+    properties.update({"contributors": [{"path": "/a/bad/path"}]})
 
     exclude = [Exclude(jsonpath=jsonpath)]
     config = Config(exclude=exclude)
-    issues = check(descriptor, config=config)
+    issues = check(properties, config=config)
 
     assert len(issues) == num_issues
 
 
 def test_exclude_jsonpath_multiple():
-    descriptor = example_package_descriptor()
-    descriptor["created"] = "20240614"
-    descriptor.update({"contributors": [{"path": "/a/bad/path"}]})
+    properties = example_package_properties()
+    properties["created"] = "20240614"
+    properties.update({"contributors": [{"path": "/a/bad/path"}]})
 
     exclude = [
         Exclude(jsonpath="$.contributors[0].path"),
         Exclude(jsonpath="$.created"),
     ]
     config = Config(exclude=exclude)
-    issues = check(descriptor, config=config)
+    issues = check(properties, config=config)
 
     assert len(issues) == 0
 
 
 def test_exclude_jsonpath_and_type():
-    descriptor = example_package_descriptor()
-    descriptor["contributors"] = [{"path": "/a/bad/path"}, {"path": "/a/bad/path"}]
+    properties = example_package_properties()
+    properties["contributors"] = [{"path": "/a/bad/path"}, {"path": "/a/bad/path"}]
 
     exclude = [
         Exclude(jsonpath="$.contributors[0].path", type="pattern"),
     ]
     config = Config(exclude=exclude)
-    issues = check(descriptor, config=config)
+    issues = check(properties, config=config)
 
     assert len(issues) == 1
 
 
 def test_exclude_jsonpath_and_type_non_overlapping():
-    descriptor = example_package_descriptor()
+    properties = example_package_properties()
     # There should be two issues
-    descriptor["created"] = "20240614"
-    descriptor.update({"contributors": [{"path": "/a/bad/path"}]})
+    properties["created"] = "20240614"
+    properties.update({"contributors": [{"path": "/a/bad/path"}]})
 
     exclude = [
         Exclude(jsonpath="$.contributors[0].path"),
         Exclude(type="pattern"),
     ]
     config = Config(exclude=exclude)
-    issues = check(descriptor, config=config)
+    issues = check(properties, config=config)
 
     # For the created field
     assert len(issues) == 1


### PR DESCRIPTION
# Description

Since we agreed in #104 that we call the `datapackage.json` file *descriptor* and metadata from the json file loaded as Python dicts *properties*. 

Needs a quick review.

## Checklist

- [X] Ran `just run-all`
