### PR TITLE
refactor: :recycle: rename `check` to `check_value` in `CustomCheck`

### DIFF
--- a/docs/guide/config.qmd
+++ b/docs/guide/config.qmd
@@ -103,7 +103,7 @@ license_check = cdp.CustomCheck(
         Data Packages may only be licensed under MIT. Please review
         the licenses listed in the Data Package.
         """),
-    check=lambda license_name: license_name == "mit",
+    check_value=lambda license_name: license_name == "mit",
 )
 ```
 

--- a/src/check_datapackage/config.py
+++ b/src/check_datapackage/config.py
@@ -28,7 +28,7 @@ class Config:
             type="only-mit",
             jsonpath="$.licenses[*].name",
             message="Data Packages may only be licensed under MIT.",
-            check=lambda license_name: license_name == "mit",
+            check_value=lambda license_name: license_name == "mit",
         )
         config = cdp.Config(exclude=[exclude_required], custom_checks=[license_check])
         ```

--- a/src/check_datapackage/custom_check.py
+++ b/src/check_datapackage/custom_check.py
@@ -19,7 +19,7 @@ class CustomCheck:
             expressed in [JSON path](https://jg-rp.github.io/python-jsonpath/syntax/)
             notation (e.g., `$.resources[*].name`).
         message (str): The message shown when the check is violated.
-        check (Callable[[Any], bool]): A function that expresses the custom check.
+        check_value (Callable[[Any], bool]): A function that expresses the custom check.
             It takes the value at the `jsonpath` location as input and
             returns true if the check is met, false if it isn't.
         type (str): An identifier for the custom check. It will be shown in error
@@ -34,14 +34,14 @@ class CustomCheck:
             type="only-mit",
             jsonpath="$.licenses[*].name",
             message="Data Packages may only be licensed under MIT.",
-            check=lambda license_name: license_name == "mit",
+            check_value=lambda license_name: license_name == "mit",
         )
         ```
     """
 
     jsonpath: str
     message: str
-    check: Callable[[Any], bool]
+    check_value: Callable[[Any], bool]
     type: str = "custom"
 
 
@@ -80,7 +80,7 @@ def _apply_custom_check(
     """
     matching_fields = _get_fields_at_jsonpath(custom_check.jsonpath, descriptor)
     failed_fields = _filter(
-        matching_fields, lambda field: not custom_check.check(field.value)
+        matching_fields, lambda field: not custom_check.check_value(field.value)
     )
     return _map(
         failed_fields,

--- a/tests/test_custom_check.py
+++ b/tests/test_custom_check.py
@@ -10,13 +10,13 @@ from check_datapackage.issue import Issue
 lowercase_check = CustomCheck(
     jsonpath="$.name",
     message="Name must be lowercase.",
-    check=lambda name: name.islower(),
+    check_value=lambda name: name.islower(),
     type="lowercase",
 )
 resource_name_check = CustomCheck(
     jsonpath="$.resources[*].name",
     message="Resource name must start with 'woolly'.",
-    check=lambda name: name.startswith("woolly"),
+    check_value=lambda name: name.startswith("woolly"),
     type="resource-name",
 )
 
@@ -90,7 +90,7 @@ def test_no_matching_jsonpath():
     custom_check = CustomCheck(
         jsonpath="$.missing",
         message="This check always fails.",
-        check=lambda value: False,
+        check_value=lambda value: False,
         type="always-fail",
     )
     config = Config(custom_checks=[custom_check])


### PR DESCRIPTION
# Description

I thought there were so many "check"s around, and this method actually checks the value of a field, not the descriptor/properties. 

Needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
