### PR TITLE
docs: :memo: describe the status icons and add planned icon

### DIFF
--- a/_variables.yml
+++ b/_variables.yml
@@ -1,2 +1,3 @@
 done: '[{{< fa check-circle size="l" title="Completed" >}}]{style="color: #47DC76"}'
 wip: '[{{< fa hammer size="l" title="In progress" >}}]{style="color: #7647DC"}'
+planned: '[{{< fa map size="l" title="Planned" >}}]{style="color: #ADADAD"}'

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -6,7 +6,7 @@ This section of the documentation focuses on the design of the interface
 and how it is implemented as Python code.
 
 ::: callout-note
-We use symbols to indicate parts of the design that are actively being worked on, 
+We use symbols to indicate parts of the design that are actively being worked on,
 done, or planned (see table below). For
 work that is planned or is in progress, we include the function
 signatures and docstrings to clarify the design. Once the interface is

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -6,13 +6,13 @@ This section of the documentation focuses on the design of the interface
 and how it is implemented as Python code.
 
 ::: callout-note
-We use symbols to indicate parts of the design that are actively being worked on,
-done, or planned (see table below). For
-work that is planned or is in progress, we include the function
-signatures and docstrings to clarify the design. Once the interface is
-implemented (done), we will remove the signatures from the documentation
-and point to the reference documentation instead. The symbols we use are
-described in the table below.
+We use symbols to indicate parts of the design that are actively being
+worked on, done, or planned (see table below). For work that is planned
+or is in progress, we include the function signatures and docstrings to
+clarify the design. Once the interface is implemented (done), we will
+remove the signatures from the documentation and point to the reference
+documentation instead. The symbols we use are described in the table
+below.
 
 | Status | Description |
 |:-----------------------------:|:----------------------------------------|

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -6,22 +6,22 @@ This section of the documentation focuses on the design of the interface
 and how it is implemented as Python code.
 
 ::: callout-note
-We use symbols to indicate parts of the design that are planned but not
-being worked on, are presently being worked on, and that are done. For
+We use symbols to indicate parts of the design that are actively being worked on, 
+done, or planned (see table below). For
 work that is planned or is in progress, we include the function
 signatures and docstrings to clarify the design. Once the interface is
 implemented (done), we will remove the signatures from the documentation
-and point instead to the reference documentation. The symbols we use are
+and point to the reference documentation instead. The symbols we use are
 described in the table below.
 
 | Status | Description |
 |:-----------------------------:|:----------------------------------------|
 | {{< var done >}} | Interface that has been implemented. |
-| {{< var wip >}} | Interface that is presently being worked on. |
-| {{< var planned >}} | Interface that is planned to be developed, but isn't a current priority. |
+| {{< var wip >}} | Interface that is currently being worked on. |
+| {{< var planned >}} | Interface that is planned, but isn't being worked on currently. |
 
-: A list of symbols used and a description of them that indicate the
-status of interface components.
+: A table showing the symbols used to indicate the status of interface
+components, along with their descriptions.
 :::
 
 ## Inputs

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -6,11 +6,22 @@ This section of the documentation focuses on the design of the interface
 and how it is implemented as Python code.
 
 ::: callout-note
-We use {{< var wip >}} to indicate parts of the design that are still a
-work in progress, which will contain the function and class signatures.
-Once the interface is implemented, indicated by {{< var done >}}, we
-will remove the signatures from the documentation and point instead to
-the reference documentation.
+We use symbols to indicate parts of the design that are planned but not
+being worked on, are presently being worked on, and that are done. For
+work that is planned or is in progress, we include the function
+signatures and docstrings to clarify the design. Once the interface is
+implemented (done), we will remove the signatures from the documentation
+and point instead to the reference documentation. The symbols we use are
+described in the table below.
+
+| Status | Description |
+|:-----------------------------:|:----------------------------------------|
+| {{< var done >}} | Interface that has been implemented. |
+| {{< var wip >}} | Interface that is presently being worked on. |
+| {{< var planned >}} | Interface that is planned to be developed, but isn't a current priority. |
+
+: A list of symbols used and a description of them that indicate the
+status of interface components.
 :::
 
 ## Inputs
@@ -66,7 +77,7 @@ decide when and how failed checks should be enforced or handled. The
 output of this function is a list of `Issue` objects, which are
 described below.
 
-### {{< var wip >}} `explain()`
+### {{< var planned >}} `explain()`
 
 The output of `check()` is a list of `Issue` objects, which are
 structured and machine-readable, but not very human-readable and
@@ -91,10 +102,10 @@ def explain(issues: list[Issue]) -> list[str]:
 ### {{< var done >}} `read_json()`
 
 This is a simple helper function to read the `datapackage.json` file
-into a Python dictionary. See [`help(read_json)`](/docs/reference/read_json.qmd)
-for more details.
+into a Python dictionary. See
+[`help(read_json)`](/docs/reference/read_json.qmd) for more details.
 
-### {{< var wip >}} `read_config()`
+### {{< var planned >}} `read_config()`
 
 This is a simple helper function to read a configuration file into a
 `Config` object for when we extend to having the configurations in a


### PR DESCRIPTION
# Description

This fills out the explanation of these statuses, plus adds a "planned" one.

Needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
