### PR TITLE
docs: :building_construction: add interface for an umbrella extensions class

### DIFF
--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -159,10 +159,16 @@ class Extension:
         import check_datapackage as cdp
 
         custom_extensions = cdp.Extension(
-            required=[cdp.Required(
-                jsonpath="$.description",
-                message="Data Packages must include a description."
-            )],
+            required=[
+                cdp.Required(
+                    jsonpath="$.description",
+                    message="Data Packages must include a description."
+                ),
+                cdp.Required(
+                    jsonpath="$.contributors[*].email",
+                    message="All contributors must have an email address."
+                )
+            ],
             custom_check=[cdp.CustomCheck(
                 type="only-mit",
                 jsonpath="$.licenses[*].name",

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -192,7 +192,7 @@ class Extensions:
         # check(descriptor, config=cdp.Config(extensions=extensions))
         ```
     """
-    required_check : list[RequiredCheck] = field(default_factory=list)
+    required_checks : list[RequiredCheck] = field(default_factory=list)
     custom_checks : list[CustomCheck] = field(default_factory=list)
 ````
 

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -181,6 +181,10 @@ class Extension:
     custom_check : Optional[list[CustomCheck]] = None
 ````
 
+Each extension class must implement it's own `apply()` method that takes
+the `datapackage.json` properties `dict` as input and outputs an `Issue`
+list that has the issues found by that extension.
+
 #### {{< var wip >}} `Required`
 
 A sub-item of `Extension` that allows users to set specific properties

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -158,23 +158,19 @@ class Extension:
         ```{python}
         import check_datapackage as cdp
 
-        exclusion_required = cdp.Extension(
+        custom_extensions = cdp.Extension(
             required=[cdp.Required(
                 jsonpath="$.description",
                 message="Data Packages must include a description."
             )],
-            custom_check=[],
+            custom_check=[cdp.CustomCheck(
+                type="only-mit",
+                jsonpath="$.licenses[*].name",
+                message="Data Packages may only be licensed under MIT.",
+                check=lambda license_name: license_name == "mit",
+            )]
         )
-        license_check = cdp.CustomCheck(
-            type="only-mit",
-            jsonpath="$.licenses[*].name",
-            message="Data Packages may only be licensed under MIT.",
-            check=lambda license_name: license_name == "mit",
-        )
-        config = cdp.Config(
-            exclusions=[exclusion_required],
-            custom_checks=[license_check],
-        )
+        # check(descriptor, config=cdp.Config(extensions=custom_extensions))
         ```
     """
     required : Optional[list[Required]] = None

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -136,21 +136,21 @@ See the help documentation with `help(Exclusion)` for more details.
 
 #### {{< var wip >}} `Extension`
 
-This sub-item of `Config` contains it's own set of sub-items that store
-extensions to the checks that `check-datapackage` runs. This `Extension`
-class can be expanded to include more types of extensions.
+This sub-item of `Config` defines extensions, i.e., additional checks that supplement those specified by the Data Package standard. It contains subitems that store
+additional checks, such as `Required` and `CustomCheck`. This `Extension`
+class might be expanded to include more types of extensions.
 
 ```` python
 @dataclass
 class Extension:
-    """Extensions to the standard checks.
+    """Extension to the standard checks.
 
     This contains additional checks to be made alongside the standard
     Data Package checks.
 
     Attributes:
-        required: A list of properties to set as required.
-        custom_check: A list of extra, custom checks to run alongside the standard
+        required: A list of `Required` objects defining properties to set as required.
+        custom_check: A list of `CustomCheck` objects defining extra, custom checks to run alongside the standard
             checks.
 
     Examples:
@@ -158,7 +158,7 @@ class Extension:
         ```{python}
         import check_datapackage as cdp
 
-        custom_extensions = cdp.Extension(
+        extensions = cdp.Extension(
             required=[
                 cdp.Required(
                     jsonpath="$.description",
@@ -176,7 +176,7 @@ class Extension:
                 check=lambda license_name: license_name == "mit",
             )]
         )
-        # check(descriptor, config=cdp.Config(extensions=custom_extensions))
+        # check(descriptor, config=cdp.Config(extensions=extensions))
         ```
     """
     required : Optional[list[Required]] = None
@@ -185,7 +185,7 @@ class Extension:
 
 Each extension class must implement it's own `apply()` method that takes
 the `datapackage.json` properties `dict` as input and outputs an `Issue`
-list that has the issues found by that extension.
+list that contains the issues found by that extension.
 
 #### {{< var wip >}} `Required`
 
@@ -195,7 +195,7 @@ help documentation with `help(Required)` for more details.
 
 #### {{< var done >}} `CustomCheck`
 
-Add an extra, custom check that `check-datapackage` will run alongside
+A sub-item of `Extension` that allows users to add an additional, custom check that `check-datapackage` will run alongside
 the standard checks. See the help documentation with `help(CustomCheck)`
 for more details.
 

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -156,26 +156,26 @@ class Extension:
     Examples:
 
         ```{python}
-import check_datapackage as cdp
+        import check_datapackage as cdp
 
-exclusion_required = cdp.Extension(
-    required=[cdp.Required(
-        jsonpath="$.description",
-        message="Data Packages must include a description."
-    )],
-    custom_check=[],
-)
-license_check = cdp.CustomCheck(
-    type="only-mit",
-    jsonpath="$.licenses[*].name",
-    message="Data Packages may only be licensed under MIT.",
-    check=lambda license_name: license_name == "mit",
-)
-config = cdp.Config(
-    exclusions=[exclusion_required],
-    custom_checks=[license_check],
-)
-```
+        exclusion_required = cdp.Extension(
+            required=[cdp.Required(
+                jsonpath="$.description",
+                message="Data Packages must include a description."
+            )],
+            custom_check=[],
+        )
+        license_check = cdp.CustomCheck(
+            type="only-mit",
+            jsonpath="$.licenses[*].name",
+            message="Data Packages may only be licensed under MIT.",
+            check=lambda license_name: license_name == "mit",
+        )
+        config = cdp.Config(
+            exclusions=[exclusion_required],
+            custom_checks=[license_check],
+        )
+        ```
     """
     required : Optional[list[Required]] = None
     custom_check : Optional[list[CustomCheck]] = None

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -91,8 +91,8 @@ def explain(issues: list[Issue]) -> list[str]:
 ### {{< var done >}} `read_json()`
 
 This is a simple helper function to read the `datapackage.json` file
-into a Python dictionary. See [`help(read_json)`](/docs/reference/read_json.qmd)
-for more details.
+into a Python dictionary. See
+[`help(read_json)`](/docs/reference/read_json.qmd) for more details.
 
 ### {{< var wip >}} `read_config()`
 
@@ -134,11 +134,64 @@ Package standard that are not relevant to your use case.
 
 See the help documentation with `help(Exclusion)` for more details.
 
+#### {{< var wip >}} `Extension`
+
+This sub-item of `Config` contains it's own set of sub-items that store
+extensions to the checks that `check-datapackage` runs. This `Extension`
+class can be expanded to include more types of extensions.
+
+```` python
+@dataclass
+class Extension:
+    """Extensions to the standard checks.
+
+    This contains additional checks to be made alongside the standard
+    Data Package checks.
+
+    Attributes:
+        required: A list of properties to set as required.
+        custom_check: A list of extra, custom checks to run alongside the standard
+            checks.
+
+    Examples:
+
+        ```{python}
+import check_datapackage as cdp
+
+exclusion_required = cdp.Extension(
+    required=[cdp.Required(
+        jsonpath="$.description",
+        message="Data Packages must include a description."
+    )],
+    custom_check=[],
+)
+license_check = cdp.CustomCheck(
+    type="only-mit",
+    jsonpath="$.licenses[*].name",
+    message="Data Packages may only be licensed under MIT.",
+    check=lambda license_name: license_name == "mit",
+)
+config = cdp.Config(
+    exclusions=[exclusion_required],
+    custom_checks=[license_check],
+)
+```
+    """
+    required : Optional[list[Required]] = None
+    custom_check : Optional[list[CustomCheck]] = None
+````
+
+#### {{< var wip >}} `Required`
+
+A sub-item of `Extension` that allows users to set specific properties
+as required that are not required by the Data Package standard. See the
+help documentation with `help(Required)` for more details.
+
 #### {{< var done >}} `CustomCheck`
 
-A sub-item of `Config`. Expresses a custom check.
-
-See the help documentation with `help(CustomCheck)` for more details.
+Add an extra, custom check that `check-datapackage` will run alongside
+the standard checks. See the help documentation with `help(CustomCheck)`
+for more details.
 
 ### {{< var done >}} `Issue`
 
@@ -148,6 +201,47 @@ Package.
 See the help documentation with
 [`help(Issue)`](/docs/reference/Issue.qmd) for more details.
 
+## {{< var planned >}} Configuration file
+
+When we develop the CLI, we'll use a config file to store the settings
+contained within the `Config` class. This file will be named `.cdp.toml`
+and will be located in the same directory as the `datapackage.json`
+file. This is an example of what that file could look like:
+
+``` toml
+# The Data Package standard version to check against.
+version = "v2"
+
+# Whether to check properties that must *and should* be included.
+strict = true
+
+# Exclude all issues related to the "resources" property.
+[[exclusions]]
+jsonpath = "$.resources"
+
+# Exclude all issues related to the "format" type in the schema.
+[[exclusions]]
+type = "format"
+
+# Exclude issues that are both a "pattern" type and found in
+# the "path" property of the "contributors" field.
+[[exclusions]]
+jsonpath = "$.contributors[*].path"
+type = "pattern"
+
+# Require that the "description" property is included in the Data Package.
+[[extensions.required]]
+jsonpath = "$.description"
+message = "This Data Package needs to include a 'description' property."
+
+# A custom check to ensure that all resource names are lowercase.
+[[extensions.custom_check]]
+jsonpath = "$.resources[*].name"
+type = "name-lowercase"
+message = "The value in the 'name' property of the 'resources' must be lowercase."
+check = "lambda name: name.islower()"
+```
+
 ## Flow
 
 This is the potential flow of using `check-datapackage`:
@@ -155,13 +249,13 @@ This is the potential flow of using `check-datapackage`:
 ```{mermaid}
 %%| label: fig-interface-flow
 %%| fig-cap: "Flow of functions and classes when using `check-datapackage`."
-%%| fig-alt: "A flowchart showing the flow of using `check-datapackage`, starting with reading the datapackage.json and .cdp.yaml files, then checking the descriptor with the config, and finally explaining any issues found."
+%%| fig-alt: "A flowchart showing the flow of using `check-datapackage`, starting with reading the datapackage.json and .cdp.toml files, then checking the descriptor with the config, and finally explaining any issues found."
 flowchart TD
     descriptor_file[(datapackage.json)]
     read_json["read_json()"]
     descriptor[/"Descriptor<br>(dict)"/]
 
-    config_file[(.cdp.yaml)]
+    config_file[(.cdp.toml)]
     read_config["read_config()"]
 
     config[/Config/]

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -136,9 +136,11 @@ See the help documentation with `help(Exclusion)` for more details.
 
 #### {{< var wip >}} `Extension`
 
-This sub-item of `Config` defines extensions, i.e., additional checks that supplement those specified by the Data Package standard. It contains subitems that store
-additional checks, such as `Required` and `CustomCheck`. This `Extension`
-class might be expanded to include more types of extensions.
+This sub-item of `Config` defines extensions, i.e., additional checks
+that supplement those specified by the Data Package standard. It
+contains subitems that store additional checks, such as `RequiredCheck`
+and `CustomCheck`. This `Extension` class might be expanded to include
+more types of extensions.
 
 ```` python
 @dataclass
@@ -149,7 +151,7 @@ class Extension:
     Data Package checks.
 
     Attributes:
-        required: A list of `Required` objects defining properties to set as required.
+        required: A list of `RequiredCheck` objects defining properties to set as required.
         custom_check: A list of `CustomCheck` objects defining extra, custom checks to run alongside the standard
             checks.
 
@@ -160,11 +162,11 @@ class Extension:
 
         extensions = cdp.Extension(
             required=[
-                cdp.Required(
+                cdp.RequiredCheck(
                     jsonpath="$.description",
                     message="Data Packages must include a description."
                 ),
-                cdp.Required(
+                cdp.RequiredCheck(
                     jsonpath="$.contributors[*].email",
                     message="All contributors must have an email address."
                 )
@@ -179,7 +181,7 @@ class Extension:
         # check(descriptor, config=cdp.Config(extensions=extensions))
         ```
     """
-    required : Optional[list[Required]] = None
+    required : Optional[list[RequiredCheck]] = None
     custom_check : Optional[list[CustomCheck]] = None
 ````
 
@@ -187,17 +189,17 @@ Each extension class must implement it's own `apply()` method that takes
 the `datapackage.json` properties `dict` as input and outputs an `Issue`
 list that contains the issues found by that extension.
 
-#### {{< var wip >}} `Required`
+#### {{< var wip >}} `RequiredCheck`
 
 A sub-item of `Extension` that allows users to set specific properties
 as required that are not required by the Data Package standard. See the
-help documentation with `help(Required)` for more details.
+help documentation with `help(RequiredCheck)` for more details.
 
 #### {{< var done >}} `CustomCheck`
 
-A sub-item of `Extension` that allows users to add an additional, custom check that `check-datapackage` will run alongside
-the standard checks. See the help documentation with `help(CustomCheck)`
-for more details.
+A sub-item of `Extension` that allows users to add an additional, custom
+check that `check-datapackage` will run alongside the standard checks.
+See the help documentation with `help(CustomCheck)` for more details.
 
 ### {{< var done >}} `Issue`
 
@@ -255,7 +257,7 @@ This is the potential flow of using `check-datapackage`:
 ```{mermaid}
 %%| label: fig-interface-flow
 %%| fig-cap: "Flow of functions and classes when using `check-datapackage`."
-%%| fig-alt: "A flowchart showing the flow of using `check-datapackage`, starting with reading the datapackage.json and .cdp.toml files, then checking the descriptor with the config, and finally explaining any issues found."
+%%| fig-alt: "A flowchart showing the flow of using `check-datapackage`, starting with reading the `datapackage.json` and `.cdp.toml` files, then checking the descriptor with the config, and finally explaining any issues found."
 flowchart TD
     descriptor_file[(datapackage.json)]
     read_json["read_json()"]

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -145,25 +145,25 @@ Package standard that are not relevant to your use case.
 
 See the help documentation with `help(Exclusion)` for more details.
 
-#### {{< var wip >}} `Extension`
+#### {{< var wip >}} `Extensions`
 
 This sub-item of `Config` defines extensions, i.e., additional checks
 that supplement those specified by the Data Package standard. It
 contains subitems that store additional checks, such as `RequiredCheck`
-and `CustomCheck`. This `Extension` class might be expanded to include
+and `CustomCheck`. This `Extensions` class might be expanded to include
 more types of extensions.
 
 ```` python
-@dataclass
-class Extension:
-    """Extension to the standard checks.
+@dataclass(frozen=True)
+class Extensions:
+    """Extensions to the standard checks.
 
     This contains additional checks to be made alongside the standard
     Data Package checks.
 
     Attributes:
-        required: A list of `RequiredCheck` objects defining properties to set as required.
-        custom_check: A list of `CustomCheck` objects defining extra, custom checks to run alongside the standard
+        required_checks: A list of `RequiredCheck` objects defining properties to set as required.
+        custom_checks: A list of `CustomCheck` objects defining extra, custom checks to run alongside the standard
             checks.
 
     Examples:
@@ -171,8 +171,8 @@ class Extension:
         ```{python}
         import check_datapackage as cdp
 
-        extensions = cdp.Extension(
-            required=[
+        extensions = cdp.Extensions(
+            required_checks=[
                 cdp.RequiredCheck(
                     jsonpath="$.description",
                     message="Data Packages must include a description."
@@ -182,7 +182,7 @@ class Extension:
                     message="All contributors must have an email address."
                 )
             ],
-            custom_check=[cdp.CustomCheck(
+            custom_checks=[cdp.CustomCheck(
                 type="only-mit",
                 jsonpath="$.licenses[*].name",
                 message="Data Packages may only be licensed under MIT.",
@@ -192,23 +192,23 @@ class Extension:
         # check(descriptor, config=cdp.Config(extensions=extensions))
         ```
     """
-    required : Optional[list[RequiredCheck]] = None
-    custom_check : Optional[list[CustomCheck]] = None
+    required_check : list[RequiredCheck] = field(default_factory=list)
+    custom_checks : list[CustomCheck] = field(default_factory=list)
 ````
 
-Each extension class must implement it's own `apply()` method that takes
+Each extension class must implement its own `apply()` method that takes
 the `datapackage.json` properties `dict` as input and outputs an `Issue`
 list that contains the issues found by that extension.
 
 #### {{< var wip >}} `RequiredCheck`
 
-A sub-item of `Extension` that allows users to set specific properties
+A sub-item of `Extensions` that allows users to set specific properties
 as required that are not required by the Data Package standard. See the
 help documentation with `help(RequiredCheck)` for more details.
 
 #### {{< var done >}} `CustomCheck`
 
-A sub-item of `Extension` that allows users to add an additional, custom
+A sub-item of `Extensions` that allows users to add an additional, custom
 check that `check-datapackage` will run alongside the standard checks.
 See the help documentation with `help(CustomCheck)` for more details.
 
@@ -249,12 +249,12 @@ jsonpath = "$.contributors[*].path"
 type = "pattern"
 
 # Require that the "description" property is included in the Data Package.
-[[extensions.required]]
+[[extensions.required_checks]]
 jsonpath = "$.description"
 message = "This Data Package needs to include a 'description' property."
 
 # A custom check to ensure that all resource names are lowercase.
-[[extensions.custom_check]]
+[[extensions.custom_checks]]
 jsonpath = "$.resources[*].name"
 type = "name-lowercase"
 message = "The value in the 'name' property of the 'resources' must be lowercase."


### PR DESCRIPTION
# Description

Related to some discussions like in #120 and #122 about how we handle custom checks/extensions to the checks against the Data Package standard.

Closes #152

Needs an in-depth review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
