### PR TITLE
docs: :pencil2: use `properties`, not `descriptor` in Interface docs

### DIFF
--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -32,8 +32,7 @@ This section describes the inputs accepted by `check-datapackage`.
     properties of a Data Package or Data Resource. Allowed properties
     are defined in the [Data Package
     standard](https://datapackage.org/). A common use case is loading
-    the properties from the `datapackage.json` file (which is called
-    a descriptor).
+    the properties from the `datapackage.json` file.
 -   **Config:** A `Config` object can optionally be passed to
     `check-datapackage` with settings to modify the behaviour and output
     of the check mechanism.

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -28,11 +28,12 @@ components, along with their descriptions.
 
 This section describes the inputs accepted by `check-datapackage`.
 
--   **Descriptor:** This is a Python dictionary containing the
+-   **Properties**: This is a Python dictionary containing the
     properties of a Data Package or Data Resource. Allowed properties
     are defined in the [Data Package
     standard](https://datapackage.org/). A common use case is loading
-    the descriptor from the `datapackage.json` file.
+    the properties from the `datapackage.json` file (which is called
+    a descriptor).
 -   **Config:** A `Config` object can optionally be passed to
     `check-datapackage` with settings to modify the behaviour and output
     of the check mechanism.
@@ -42,7 +43,7 @@ This section describes the inputs accepted by `check-datapackage`.
 ## Outputs
 
 For each failed check, `check-datapackage` flags the corresponding issue
-in the descriptor. If all checks pass, an empty list is returned.
+in the properties. If all checks pass, an empty list is returned.
 
 -   Default mode: The issues are returned as a list without stopping
     program execution.
@@ -64,7 +65,7 @@ for now though.
 ### {{< var wip >}} `check()`
 
 This is the main function of this package, which will check a Data
-Package descriptor against the Data Package standard, as well as include
+Package properties against the Data Package standard, as well as include
 any custom exclusions or custom checks listed in the configuration.
 
 See the help documentation with `help(check)` for more details.
@@ -91,7 +92,7 @@ def explain(issues: list[Issue]) -> list[str]:
 
     Args:
         issues: A list of `Issue` objects representing issues found while
-            checking a Data Package descriptor.
+            checking a Data Package properties.
 
     Returns:
         A list of user-friendly, human-readable messages
@@ -169,6 +170,7 @@ class Extensions:
     Examples:
 
         ```{python}
+        #| eval: false
         import check_datapackage as cdp
 
         extensions = cdp.Extensions(
@@ -189,7 +191,7 @@ class Extensions:
                 check=lambda license_name: license_name == "mit",
             )]
         )
-        # check(descriptor, config=cdp.Config(extensions=extensions))
+        # check(properties, config=cdp.Config(extensions=extensions))
         ```
     """
     required_checks : list[RequiredCheck] = field(default_factory=list)
@@ -268,11 +270,11 @@ This is the potential flow of using `check-datapackage`:
 ```{mermaid}
 %%| label: fig-interface-flow
 %%| fig-cap: "Flow of functions and classes when using `check-datapackage`."
-%%| fig-alt: "A flowchart showing the flow of using `check-datapackage`, starting with reading the `datapackage.json` and `.cdp.toml` files, then checking the descriptor with the config, and finally explaining any issues found."
+%%| fig-alt: "A flowchart showing the flow of using `check-datapackage`, starting with reading the `datapackage.json` and `.cdp.toml` files, then checking the properties with the config, and finally explaining any issues found."
 flowchart TD
     descriptor_file[(datapackage.json)]
     read_json["read_json()"]
-    descriptor[/"Descriptor<br>(dict)"/]
+    properties[/"Properties<br>(dict)"/]
 
     config_file[(.cdp.toml)]
     read_config["read_config()"]
@@ -286,10 +288,10 @@ flowchart TD
     explain["explain()"]
     messages[/messages/]
 
-    descriptor_file --> read_json --> descriptor
+    descriptor_file --> read_json --> properties
     config_file --> read_config --> config
     custom_check & exclusion --> config
     custom_check & exclusion -.-> config_file
 
-    descriptor & config --> check --> issues --> explain --> messages
+    properties & config --> check --> issues --> explain --> messages
 ```

--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -29,11 +29,10 @@ components, along with their descriptions.
 This section describes the inputs accepted by `check-datapackage`.
 
 -   **Properties**: This is a Python dictionary containing the
-    properties of a Data Package or Data Resource. Allowed properties
-    are defined in the [Data Package
-    standard](https://datapackage.org/). A common use case is loading
-    the properties from the `datapackage.json` file (which is called
-    a descriptor).
+    properties of a Data Package. Allowed properties are defined in the
+    [Data Package standard](https://datapackage.org/). A common use case
+    is loading the properties from the `datapackage.json` file (which is
+    called a descriptor).
 -   **Config:** A `Config` object can optionally be passed to
     `check-datapackage` with settings to modify the behaviour and output
     of the check mechanism.
@@ -170,29 +169,29 @@ class Extensions:
     Examples:
 
         ```{python}
-        #| eval: false
-        import check_datapackage as cdp
+#| eval: false
+import check_datapackage as cdp
 
-        extensions = cdp.Extensions(
-            required_checks=[
-                cdp.RequiredCheck(
-                    jsonpath="$.description",
-                    message="Data Packages must include a description."
-                ),
-                cdp.RequiredCheck(
-                    jsonpath="$.contributors[*].email",
-                    message="All contributors must have an email address."
-                )
-            ],
-            custom_checks=[cdp.CustomCheck(
-                type="only-mit",
-                jsonpath="$.licenses[*].name",
-                message="Data Packages may only be licensed under MIT.",
-                check=lambda license_name: license_name == "mit",
-            )]
+extensions = cdp.Extensions(
+    required_checks=[
+        cdp.RequiredCheck(
+            jsonpath="$.description",
+            message="Data Packages must include a description."
+        ),
+        cdp.RequiredCheck(
+            jsonpath="$.contributors[*].email",
+            message="All contributors must have an email address."
         )
-        # check(properties, config=cdp.Config(extensions=extensions))
-        ```
+    ],
+    custom_checks=[cdp.CustomCheck(
+        type="only-mit",
+        jsonpath="$.licenses[*].name",
+        message="Data Packages may only be licensed under MIT.",
+        check=lambda license_name: license_name == "mit",
+    )]
+)
+# check(properties, config=cdp.Config(extensions=extensions))
+```
     """
     required_checks : list[RequiredCheck] = field(default_factory=list)
     custom_checks : list[CustomCheck] = field(default_factory=list)
@@ -210,9 +209,10 @@ help documentation with `help(RequiredCheck)` for more details.
 
 #### {{< var done >}} `CustomCheck`
 
-A sub-item of `Extensions` that allows users to add an additional, custom
-check that `check-datapackage` will run alongside the standard checks.
-See the help documentation with `help(CustomCheck)` for more details.
+A sub-item of `Extensions` that allows users to add an additional,
+custom check that `check-datapackage` will run alongside the standard
+checks. See the help documentation with `help(CustomCheck)` for more
+details.
 
 ### {{< var done >}} `Issue`
 


### PR DESCRIPTION
# Description

Needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
