### PR TITLE
refactor: :recycle: handle grouped errors without modifying input

### DIFF
--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -1,7 +1,7 @@
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import reduce
-from typing import Any, Iterator, Optional
+from typing import Any, Callable, Iterator, Optional
 
 from jsonschema import Draft7Validator, FormatChecker, ValidationError
 
@@ -137,46 +137,31 @@ def _validation_errors_to_issues(
     return _map(schema_errors, _create_issue)
 
 
-def _handle_grouped_error(
-    schema_errors: list[SchemaError], parent_error: SchemaError
-) -> list[SchemaError]:
-    """Handle grouped schema errors that need special treatment.
+@dataclass(frozen=True)
+class SchemaErrorEdits:
+    """Expresses which errors to add to or remove from schema errors."""
 
-    Args:
-        schema_errors: All remaining schema errors.
-        parent_error: The parent error of a group.
-
-    Returns:
-        The schema errors after processing.
-    """
-    # Handle issues at $.resources[x]
-
-    if parent_error.schema_path.endswith("resources/items/oneOf"):
-        schema_errors = _handle_S_resources_x(parent_error, schema_errors)
-
-    # Handle issues at $.resources[x].path
-    if parent_error.schema_path.endswith("resources/items/properties/path/oneOf"):
-        schema_errors = _handle_S_resources_x_path(parent_error, schema_errors)
-
-    return schema_errors
+    add: list[SchemaError] = field(default_factory=list)
+    remove: list[SchemaError] = field(default_factory=list)
 
 
 def _handle_S_resources_x(
     parent_error: SchemaError,
     schema_errors: list[SchemaError],
-) -> list[SchemaError]:
+) -> SchemaErrorEdits:
     """Do not flag missing `path` and `data` separately."""
+    edits = SchemaErrorEdits()
     errors_in_group = _filter(schema_errors, lambda error: error.parent == parent_error)
     # If the parent error is caused by other errors, remove it
     if errors_in_group:
-        schema_errors.remove(parent_error)
+        edits.remove.append(parent_error)
 
     path_or_data_required_errors = _filter(
         errors_in_group, _path_or_data_required_error
     )
     # If path and data are both missing, add a more informative error
     if len(path_or_data_required_errors) > 1:
-        schema_errors.append(
+        edits.add.append(
             SchemaError(
                 message=(
                     "This resource has no `path` or `data` field. "
@@ -189,31 +174,31 @@ def _handle_S_resources_x(
         )
 
     # Remove all required errors on path and data
-    return _filter(
-        schema_errors, lambda error: error not in path_or_data_required_errors
-    )
+    edits.remove.extend(path_or_data_required_errors)
+    return edits
 
 
 def _handle_S_resources_x_path(
     parent_error: SchemaError,
     schema_errors: list[SchemaError],
-) -> list[SchemaError]:
+) -> SchemaErrorEdits:
     """Only flag errors for the relevant type.
 
     If `path` is a string, flag errors for the string-based schema.
     If `path` is an array, flag errors for the array-based schema.
     """
+    edits = SchemaErrorEdits()
     errors_in_group = _filter(schema_errors, lambda error: error.parent == parent_error)
     type_errors = _filter(errors_in_group, _is_path_type_error)
     only_type_errors = len(errors_in_group) == len(type_errors)
 
     if type_errors:
-        schema_errors.remove(parent_error)
+        edits.remove.append(parent_error)
 
     # If the only error is that $.resources[x].path is of the wrong type,
     # add a more informative error
     if only_type_errors:
-        schema_errors.append(
+        edits.add.append(
             SchemaError(
                 message="The `path` property must be either a string or an array.",
                 type="type",
@@ -223,7 +208,39 @@ def _handle_S_resources_x_path(
         )
 
     # Remove all original type errors on $.resources[x].path
-    return _filter(schema_errors, lambda error: error not in type_errors)
+    edits.remove.extend(type_errors)
+    return edits
+
+
+schema_path_to_handler: dict[
+    str, Callable[[SchemaError, list[SchemaError]], SchemaErrorEdits]
+] = {
+    "resources/items/oneOf": _handle_S_resources_x,
+    "resources/items/properties/path/oneOf": _handle_S_resources_x_path,
+}
+
+
+def _handle_grouped_error(
+    schema_errors: list[SchemaError], parent_error: SchemaError
+) -> list[SchemaError]:
+    """Handle grouped schema errors that need special treatment.
+
+    Args:
+        schema_errors: All remaining schema errors.
+        parent_error: The parent error of a group.
+
+    Returns:
+        The schema errors after processing.
+    """
+    add = []
+    remove = []
+    for schema_path, handler in schema_path_to_handler.items():
+        if parent_error.schema_path.endswith(schema_path):
+            edits = handler(parent_error, schema_errors)
+            add.extend(edits.add)
+            remove.extend(edits.remove)
+
+    return _filter(schema_errors, lambda error: error not in remove) + add
 
 
 def _validation_error_to_schema_errors(error: ValidationError) -> list[SchemaError]:

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -212,12 +212,12 @@ def _handle_S_resources_x_path(
     return edits
 
 
-_schema_path_to_handler: dict[
-    str, Callable[[SchemaError, list[SchemaError]], SchemaErrorEdits]
-] = {
-    "resources/items/oneOf": _handle_S_resources_x,
-    "resources/items/properties/path/oneOf": _handle_S_resources_x_path,
-}
+_schema_path_to_handler: list[
+    tuple[str, Callable[[SchemaError, list[SchemaError]], SchemaErrorEdits]]
+] = [
+    ("resources/items/oneOf", _handle_S_resources_x),
+    ("resources/items/properties/path/oneOf", _handle_S_resources_x_path),
+]
 
 
 def _handle_grouped_error(
@@ -252,7 +252,7 @@ def _handle_grouped_error(
             remove=edits.remove + next_edits.remove,
         )
 
-    edits = _get_edits(list(_schema_path_to_handler.items()))
+    edits = _get_edits(_schema_path_to_handler)
     return _filter(schema_errors, lambda error: error not in edits.remove) + edits.add
 
 


### PR DESCRIPTION
# Description
This is a refactor of how the functions that handle grouped errors handle those grouped errors.

Previously they took in all `schema_errors` as input, added and removed errors, and returned a modified list.

The more functions we have, the messier this becomes, so this PR refactors the functions to return a list of errors to add and a list of errors to remove. Then, we can just do all additions and removals once at the end.

Needs an in-depth review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
