### PR TITLE
docs: :lipstick: prettify the guide list in the landing page

### DIFF
--- a/docs/guide/check.qmd
+++ b/docs/guide/check.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Checking a Data Package's metadata"
+description: "A brief walkthrough on how you can use the `check()` function to confirm that the metadata in your `datapackage.json` file complies with the Data Package standard."
 jupyter: python3
 order: 1
 ---

--- a/docs/guide/config.qmd
+++ b/docs/guide/config.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Configuring the checks"
+description: "Customise the types of checks that are done against your `datapackage.json` by using the `Config` class, such as excluding certain checks or adding your own."
 jupyter: python3
 order: 3
 ---

--- a/docs/guide/config.qmd
+++ b/docs/guide/config.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Configuring the checks"
-description: "Customise the types of checks that are done against your `datapackage.json` by using the `Config` class, such as excluding certain checks or adding your own."
+description: "A simple introduction to customising the types of checks that are done against your `datapackage.json` by using the `Config` class, such as excluding certain checks or adding your own."
 jupyter: python3
 order: 3
 ---

--- a/docs/guide/index.qmd
+++ b/docs/guide/index.qmd
@@ -5,7 +5,6 @@ listing:
     contents: .
     type: grid
     grid-columns: 1
-    grid-item-border: false
     sort: "order"
     fields:
         - title

--- a/docs/guide/index.qmd
+++ b/docs/guide/index.qmd
@@ -4,7 +4,10 @@ description: "A guide on using `check-datapackage` to check the compliance of yo
 listing:
     contents: .
     type: grid
+    grid-columns: 1
+    grid-item-border: false
     sort: "order"
     fields:
         - title
+        - description
 ---

--- a/docs/guide/issues.qmd
+++ b/docs/guide/issues.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Understanding issues"
+description: "A short description about the `Issue` class that contains any problems found in your metadata when using `check()` on a `datapackage.json` file."
 jupyter: python3
 order: 2
 ---


### PR DESCRIPTION
# Description

Makes it a list of items, rather than a row of them. Adds description to fill in the space a bit.

Needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
