### PR TITLE
feat: :sparkles: disallow intersection JSON path operator

### DIFF
--- a/src/check_datapackage/internals.py
+++ b/src/check_datapackage/internals.py
@@ -72,6 +72,7 @@ def _is_jsonpath(value: str) -> str:
             "https://jg-rp.github.io/python-jsonpath/syntax/ for the expected syntax."
         )
 
+    # Doesn't allow intersection paths (e.g. `$.resources & $.name`).
     intersection_token = jsonpath.env.intersection_token
     if isinstance(jsonpath, CompoundJSONPath) and _filter(
         jsonpath.paths, lambda path: path[0] == intersection_token

--- a/src/check_datapackage/internals.py
+++ b/src/check_datapackage/internals.py
@@ -72,12 +72,13 @@ def _is_jsonpath(value: str) -> str:
             "https://jg-rp.github.io/python-jsonpath/syntax/ for the expected syntax."
         )
 
+    intersection_token = jsonpath.env.intersection_token
     if isinstance(jsonpath, CompoundJSONPath) and _filter(
-        jsonpath.paths, lambda path: path[0] == "&"
+        jsonpath.paths, lambda path: path[0] == intersection_token
     ):
         raise ValueError(
-            f"The intersection operator (`&`) in the JSON path '{value}' is not "
-            "supported."
+            f"The intersection operator (`{intersection_token}`) in the JSON path "
+            f"'{value}' is not supported."
         )
     return value
 

--- a/src/check_datapackage/internals.py
+++ b/src/check_datapackage/internals.py
@@ -2,7 +2,13 @@ from dataclasses import dataclass
 from itertools import chain
 from typing import Annotated, Any, Callable, Iterable, TypeVar
 
-from jsonpath import JSONPathMatch, JSONPathSyntaxError, compile, finditer
+from jsonpath import (
+    CompoundJSONPath,
+    JSONPathMatch,
+    JSONPathSyntaxError,
+    compile,
+    finditer,
+)
 from pydantic import AfterValidator
 
 
@@ -59,11 +65,19 @@ def _flat_map(items: Iterable[In], fn: Callable[[In], Iterable[Out]]) -> list[Ou
 
 def _is_jsonpath(value: str) -> str:
     try:
-        compile(value)
+        jsonpath = compile(value)
     except JSONPathSyntaxError:
         raise ValueError(
             f"'{value}' is not a correct JSON path. See "
             "https://jg-rp.github.io/python-jsonpath/syntax/ for the expected syntax."
+        )
+
+    if isinstance(jsonpath, CompoundJSONPath) and _filter(
+        jsonpath.paths, lambda path: path[0] == "&"
+    ):
+        raise ValueError(
+            f"The intersection operator (`&`) in the JSON path '{value}' is not "
+            "supported."
         )
     return value
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -168,6 +168,8 @@ def test_required_check_array_wildcard():
         "..resources",
         "$.resources[0].*",
         "$.resources[*]",
+        "$.no & $.intersection",
+        "$.no & $.intersection | $.operator",
     ],
 )
 def test_required_check_cannot_apply_to_bad_or_ambiguous_path(jsonpath):
@@ -178,10 +180,18 @@ def test_required_check_cannot_apply_to_bad_or_ambiguous_path(jsonpath):
         )
 
 
-def test_custom_check_cannot_apply_to_bad_path():
+@mark.parametrize(
+    "jsonpath",
+    [
+        "<><>bad.path",
+        "$.no & $.intersection",
+        "$.no & $.intersection | $.operator",
+    ],
+)
+def test_custom_check_cannot_apply_to_bad_path(jsonpath):
     with raises(ValueError):
         CustomCheck(
-            jsonpath="<><>bad.path",
+            jsonpath=jsonpath,
             message="A message.",
             check=lambda _: True,
         )


### PR DESCRIPTION
# Description

This PR disallows the intersection operator for the reasons listed in the issue.

Closes #202 

Needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
