### PR TITLE
fix: :bug: sort and deduplicate issues before raising error

### DIFF
--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -89,11 +89,12 @@ def check(
     issues = _check_object_against_json_schema(properties, schema)
     issues += apply_extensions(properties, config.extensions)
     issues = exclude(issues, config.exclusions, properties)
+    issues = sorted(set(issues))
 
     if error and issues:
         raise DataPackageError(issues)
 
-    return sorted(set(issues))
+    return issues
 
 
 def _set_should_fields_to_required(schema: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -630,6 +630,15 @@ def test_fail_primary_key_with_bad_array_item():
 
 
 def test_error_as_true():
+    properties = {
+        "name": 123,
+    }
+
+    with raises(DataPackageError):
+        check(properties, error=True)
+
+
+def test_error_true_no_duplicate_issues():
     resources_required = RequiredCheck(
         jsonpath="$.resources",
         message="'resources' is a required property",

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -10,7 +10,7 @@ from check_datapackage.examples import (
     example_resource_properties,
 )
 from check_datapackage.exclusion import Exclusion
-from check_datapackage.extensions import Extensions
+from check_datapackage.extensions import Extensions, RequiredCheck
 from check_datapackage.internals import _map
 from tests.test_extensions import lowercase_check
 
@@ -630,9 +630,16 @@ def test_fail_primary_key_with_bad_array_item():
 
 
 def test_error_as_true():
-    properties = {
-        "name": 123,
-    }
+    resources_required = RequiredCheck(
+        jsonpath="$.resources",
+        message="'resources' is a required property",
+    )
 
-    with raises(DataPackageError):
-        check(properties, error=True)
+    with raises(DataPackageError) as error:
+        check(
+            {},
+            error=True,
+            config=Config(extensions=Extensions(required_checks=[resources_required])),
+        )
+
+    assert str(error).count(resources_required.message) == 1


### PR DESCRIPTION
# Description

This PR moves issue sorting and deduplication before raising an error (when `error=True`). Otherwise, the error message has unsorted, potentially repeated errors.

Needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
