### PR TITLE
feat: :sparkles: `explain()` errors

### DIFF
--- a/docs/design/interface.qmd
+++ b/docs/design/interface.qmd
@@ -76,7 +76,7 @@ decide when and how failed checks should be enforced or handled. The
 output of this function is a list of `Issue` objects, which are
 described below.
 
-### {{< var planned >}} `explain()`
+### {{< var done >}} `explain()`
 
 The output of `check()` is a list of `Issue` objects, which are
 structured and machine-readable, but not very human-readable and

--- a/docs/guide/issues.qmd
+++ b/docs/guide/issues.qmd
@@ -12,9 +12,6 @@ properties. An `Issue` has attributes that provide information about the
 failed check, which are described in more detail in the
 [`Issue`](/docs/reference/Issue.qmd) documentation.
 
-<!-- TODO: Unhide this after it has been implemented. -->
-
-::: content-hidden
 ## The `explain()` function
 
 The `explain()` function provides a more verbose and user-friendly
@@ -40,4 +37,3 @@ cdp.explain(issues)
 
 When setting `error=True` in `check()`, error messages will be generated
 by the `explain()` function.
-:::

--- a/src/check_datapackage/__init__.py
+++ b/src/check_datapackage/__init__.py
@@ -1,6 +1,6 @@
 """Check functions and constants for the Frictionless Data Package standard."""
 
-from .check import DataPackageError, check
+from .check import DataPackageError, check, explain
 from .config import Config
 from .examples import (
     example_field_properties,
@@ -24,5 +24,6 @@ __all__ = [
     "example_resource_properties",
     "example_field_properties",
     "check",
+    "explain",
     "read_json",
 ]

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -602,7 +602,11 @@ def _create_issue(error: SchemaError) -> Issue:
         message=error.message,
         jsonpath=error.jsonpath,
         type=error.type,
-        instance=error.instance,
+        instance=(
+            None
+            if error.type in ("required", "minItems", "oneOf", "enum", "uniqueItems")
+            else error.instance,
+        ),
     )
 
 

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -55,7 +55,7 @@ class DataPackageError(Exception):
             explain,
         )
         message: str = (
-            "There were some issues found in your `datapackage.json`:\n\n"
+            f"There were {len(errors)} issues found in your `datapackage.json`:\n\n"
             + "\n".join(errors)
         )
         super().__init__(message)

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -78,8 +78,10 @@ def explain(issues: list[Issue]) -> str:
         issues,
         _create_explanation,
     )
+    num_issues = len(issue_explanations)
+    singular_or_plural = " was" if num_issues == 1 else "s were"
     return (
-        f"{len(issue_explanations)} issues were found in your `datapackage.json`:\n\n"
+        f"{num_issues} issue{singular_or_plural} found in your `datapackage.json`:\n\n"
         + "\n".join(issue_explanations)
     )
 

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -3,7 +3,7 @@ import sys
 from dataclasses import dataclass, field
 from functools import reduce
 from types import TracebackType
-from typing import Any, Callable, Iterator, Optional
+from typing import Any, Callable, Hashable, Iterator, Optional
 
 from jsonschema import Draft7Validator, FormatChecker, ValidationError
 
@@ -602,11 +602,8 @@ def _create_issue(error: SchemaError) -> Issue:
         message=error.message,
         jsonpath=error.jsonpath,
         type=error.type,
-        instance=(
-            None
-            if error.type in ("required", "minItems", "oneOf", "enum", "uniqueItems")
-            else error.instance,
-        ),
+        # Since we want to deduplicate issues, only include instance if it's hashable
+        instance=error.instance if isinstance(error.instance, Hashable) else None,
     )
 
 

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -52,13 +52,32 @@ class DataPackageError(Exception):
         # TODO: Switch to using `explain()` once implemented
         errors: list[str] = _map(
             issues,
-            lambda issue: f"- Property `{issue.jsonpath}`: {issue.message}\n",
+            explain,
         )
         message: str = (
             "There were some issues found in your `datapackage.json`:\n\n"
             + "\n".join(errors)
         )
         super().__init__(message)
+
+
+def explain(issue: Issue) -> str:
+    """Explain the issue in a human-readable format.
+
+    Args:
+        issue: The `Issue` object to explain.
+
+    Returns:
+        A human-readable explanation of the issue.
+    """
+    property_name = issue.jsonpath.split(".")[-1]
+    return (  # noqa: F401
+        f"At package.{issue.jsonpath[2:]}:\n"  # indexing to remove '$.'
+        "|\n"
+        f"| {property_name}: {issue.instance!r}\n"
+        f"| {' ' * len(property_name)}  {'^' * len(str(issue.instance))}\n"
+        f"{issue.message}\n"
+    )
 
 
 def check(
@@ -578,6 +597,7 @@ def _create_issue(error: SchemaError) -> Issue:
         message=error.message,
         jsonpath=error.jsonpath,
         type=error.type,
+        instance=error.instance,
     )
 
 

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -66,7 +66,7 @@ def explain(issues: list[Issue]) -> str:
         _create_explanation,
     )
     error_message: str = (
-        f"There were {len(issue_explanations)} issues found in your `datapackage.json`:\n\n"
+        f"{len(issue_explanations)} issues were found in your `datapackage.json`:\n\n"
         + "\n".join(issue_explanations)
     )
     return error_message

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -61,19 +61,19 @@ def explain(issues: list[Issue]) -> str:
     Returns:
         A human-readable explanation of the issue.
     """
-    issue_messages: list[str] = _map(
+    issue_explanations: list[str] = _map(
         issues,
-        _create_issue_message,
+        _create_explanation,
     )
     error_message: str = (
-        f"There were {len(issue_messages)} issues found in your `datapackage.json`:\n\n"
-        + "\n".join(issue_messages)
+        f"There were {len(issue_explanations)} issues found in your `datapackage.json`:\n\n"
+        + "\n".join(issue_explanations)
     )
     return error_message
 
 
-def _create_issue_message(issue: Issue) -> str:
-    """Create an informative message of what went wrong in each issue."""
+def _create_explanation(issue: Issue) -> str:
+    """Create an informative explanation of what went wrong in each issue."""
     property_name = issue.jsonpath.split(".")[-1]
     return (  # noqa: F401
         f"At package.{issue.jsonpath[2:]}:\n"  # indexing to remove '$.'

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -88,11 +88,13 @@ def explain(issues: list[Issue]) -> str:
 def _create_explanation(issue: Issue) -> str:
     """Create an informative explanation of what went wrong in each issue."""
     property_name = issue.jsonpath.split(".")[-1]
+    # Two extra carets are added for string instances to account for quotes
+    number_of_carets = len(str(issue.instance)) + 2 * isinstance(issue.instance, str)
     return (  # noqa: F401
         f"At package.{issue.jsonpath[2:]}:\n"  # indexing to remove '$.'
         "|\n"
         f"| {property_name}: {issue.instance!r}\n"
-        f"| {' ' * len(property_name)}  {'^' * len(str(issue.instance))}\n"
+        f"| {' ' * len(property_name)}  {'^' * number_of_carets}\n"
         f"{issue.message}\n"
     )
 

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -90,8 +90,7 @@ def _create_explanation(issue: Issue) -> str:
     """Create an informative explanation of what went wrong in each issue."""
     # Remove suffix '$' to account for root path when `[]` is passed to `check()`
     property_name = issue.jsonpath.removesuffix("$").split(".")[-1]
-    # Two extra carets are added for string instances to account for quotes
-    number_of_carets = len(str(issue.instance)) + 2 * isinstance(issue.instance, str)
+    number_of_carets = len(str(issue.instance))
     return (  # noqa: F401
         f"At package{issue.jsonpath.removeprefix('$')}:\n"
         "|\n"

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -78,11 +78,10 @@ def explain(issues: list[Issue]) -> str:
         issues,
         _create_explanation,
     )
-    error_message: str = (
+    return (
         f"{len(issue_explanations)} issues were found in your `datapackage.json`:\n\n"
         + "\n".join(issue_explanations)
     )
-    return error_message
 
 
 def _create_explanation(issue: Issue) -> str:

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -60,6 +60,19 @@ def explain(issues: list[Issue]) -> str:
 
     Returns:
         A human-readable explanation of the issue.
+
+    Examples:
+        ```{python}
+        import check_datapackage as cdp
+
+        issue = cdp.Issue(
+            jsonpath="$.resources[2].title",
+            type="required",
+            message="The `title` field is required but missing at the given JSON path.",
+        )
+
+        cdp.explain([issue])
+        ```
     """
     issue_explanations: list[str] = _map(
         issues,

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -53,13 +53,13 @@ class DataPackageError(Exception):
 
 
 def explain(issues: list[Issue]) -> str:
-    """Explain the issue in a human-readable format.
+    """Explain the issues in a human-readable format.
 
     Args:
         issues: A list of `Issue` objects to explain.
 
     Returns:
-        A human-readable explanation of the issue.
+        A human-readable explanation of the issues.
 
     Examples:
         ```{python}

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -3,7 +3,7 @@ import sys
 from dataclasses import dataclass, field
 from functools import reduce
 from types import TracebackType
-from typing import Any, Callable, Hashable, Iterator, Optional
+from typing import Any, Callable, Iterator, Optional
 
 from jsonschema import Draft7Validator, FormatChecker, ValidationError
 
@@ -617,8 +617,7 @@ def _create_issue(error: SchemaError) -> Issue:
         message=error.message,
         jsonpath=error.jsonpath,
         type=error.type,
-        # Since we want to deduplicate issues, only include instance if it's hashable
-        instance=error.instance if isinstance(error.instance, Hashable) else None,
+        instance=error.instance,
     )
 
 

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -88,13 +88,14 @@ def explain(issues: list[Issue]) -> str:
 
 def _create_explanation(issue: Issue) -> str:
     """Create an informative explanation of what went wrong in each issue."""
-    property_name = issue.jsonpath.split(".")[-1]
+    # Remove suffix '$' to account for root path when `[]` is passed to `check()`
+    property_name = issue.jsonpath.removesuffix("$").split(".")[-1]
     # Two extra carets are added for string instances to account for quotes
     number_of_carets = len(str(issue.instance)) + 2 * isinstance(issue.instance, str)
     return (  # noqa: F401
-        f"At package.{issue.jsonpath[2:]}:\n"  # indexing to remove '$.'
+        f"At package{issue.jsonpath.removeprefix('$')}:\n"
         "|\n"
-        f"| {property_name}: {issue.instance!r}\n"
+        f"| {property_name}{': ' if property_name else '  '}{issue.instance}\n"
         f"| {' ' * len(property_name)}  {'^' * number_of_carets}\n"
         f"{issue.message}\n"
     )

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -48,28 +48,32 @@ class DataPackageError(Exception):
         self,
         issues: list[Issue],
     ) -> None:
-        """Create the DataPackageError attributes from issues."""
-        # TODO: Switch to using `explain()` once implemented
-        errors: list[str] = _map(
-            issues,
-            explain,
-        )
-        message: str = (
-            f"There were {len(errors)} issues found in your `datapackage.json`:\n\n"
-            + "\n".join(errors)
-        )
-        super().__init__(message)
+        """Create the DataPackageError from issues."""
+        super().__init__(explain(issues))
 
 
-def explain(issue: Issue) -> str:
+def explain(issues: list[Issue]) -> str:
     """Explain the issue in a human-readable format.
 
     Args:
-        issue: The `Issue` object to explain.
+        issues: A list of `Issue` objects to explain.
 
     Returns:
         A human-readable explanation of the issue.
     """
+    issue_messages: list[str] = _map(
+        issues,
+        _create_issue_message,
+    )
+    error_message: str = (
+        f"There were {len(issue_messages)} issues found in your `datapackage.json`:\n\n"
+        + "\n".join(issue_messages)
+    )
+    return error_message
+
+
+def _create_issue_message(issue: Issue) -> str:
+    """Create an informative message of what went wrong in each issue."""
     property_name = issue.jsonpath.split(".")[-1]
     return (  # noqa: F401
         f"At package.{issue.jsonpath[2:]}:\n"  # indexing to remove '$.'

--- a/src/check_datapackage/extensions.py
+++ b/src/check_datapackage/extensions.py
@@ -59,6 +59,7 @@ class CustomCheck(BaseModel, frozen=True):
     message: str
     check: Callable[[Any], bool]
     type: str = "custom"
+    instance: Any = None
 
     @field_validator("type", mode="after")
     @classmethod
@@ -162,6 +163,7 @@ class RequiredCheck(BaseModel, frozen=True):
     jsonpath: JsonPath
     message: str
     _targets: list[TargetJsonPath] = PrivateAttr()
+    instance: Any = None
 
     @model_validator(mode="after")
     def _check_field_name_in_jsonpath(self) -> Self:

--- a/src/check_datapackage/extensions.py
+++ b/src/check_datapackage/extensions.py
@@ -59,7 +59,6 @@ class CustomCheck(BaseModel, frozen=True):
     message: str
     check: Callable[[Any], bool]
     type: str = "custom"
-    instance: Any = None
 
     @field_validator("type", mode="after")
     @classmethod
@@ -163,7 +162,6 @@ class RequiredCheck(BaseModel, frozen=True):
     jsonpath: JsonPath
     message: str
     _targets: list[TargetJsonPath] = PrivateAttr()
-    instance: Any = None
 
     @model_validator(mode="after")
     def _check_field_name_in_jsonpath(self) -> Self:

--- a/src/check_datapackage/issue.py
+++ b/src/check_datapackage/issue.py
@@ -16,6 +16,7 @@ class Issue:
             as "required", "type", "pattern", or "format", or a custom type). Used to
             exclude specific types of issues.
         message (string): A description of what exactly the issue is.
+        instance (Any): The part of the object that failed the check.
 
     Examples:
         ```{python}

--- a/src/check_datapackage/issue.py
+++ b/src/check_datapackage/issue.py
@@ -32,4 +32,4 @@ class Issue:
     jsonpath: str
     type: str
     message: str
-    instance: Any
+    instance: Any = None

--- a/src/check_datapackage/issue.py
+++ b/src/check_datapackage/issue.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 
@@ -16,7 +16,8 @@ class Issue:
             as "required", "type", "pattern", or "format", or a custom type). Used to
             exclude specific types of issues.
         message (string): A description of what exactly the issue is.
-        instance (Any): The part of the object that failed the check.
+        instance (Any): The part of the object that failed the check. This field is not
+            considered when comparing or hashing `Issue` objects.
 
     Examples:
         ```{python}
@@ -33,4 +34,4 @@ class Issue:
     jsonpath: str
     type: str
     message: str
-    instance: Any = None
+    instance: Any = field(default=None, compare=False, hash=False)

--- a/src/check_datapackage/issue.py
+++ b/src/check_datapackage/issue.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(order=True, frozen=True)
@@ -31,3 +32,4 @@ class Issue:
     jsonpath: str
     type: str
     message: str
+    instance: Any


### PR DESCRIPTION
Creates a more human readable format to explain error messages

Closes #11, closes #58, closes #14

Needs an in-depth review.

## Checklist

- [x] Ran `just run-all`
