### PR TITLE
feat: :sparkles: check primary key exists

### DIFF
--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -150,11 +150,11 @@ def _check_keys(properties: dict[str, Any], issues: list[Issue]) -> list[Issue]:
     resources_with_pk = _keep_resources_with_no_issue_at_property(
         resources_with_pk, issues, "schema.primaryKey"
     )
-    issues = _flat_map(resources_with_pk, _check_primary_key)
+    key_issues = _flat_map(resources_with_pk, _check_primary_key)
 
     # Foreign keys
 
-    return issues
+    return key_issues
 
 
 def _issues_at_property(

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -172,8 +172,9 @@ def _only_resources_with_correct_property_at(
 
 def _check_primary_key(resource: PropertyField) -> list[Issue]:
     """Check that primary key fields exist in the resource."""
-    pk_fields = _key_fields_as_str_list(resolve("/schema/primaryKey", resource.value))
-    unknown_fields = _get_unknown_key_fields(pk_fields, resource.value)
+    pk_fields = resolve("/schema/primaryKey", resource.value)
+    pk_fields_list = _key_fields_as_str_list(pk_fields)
+    unknown_fields = _get_unknown_key_fields(pk_fields_list, resource.value)
 
     if not unknown_fields:
         return []
@@ -185,6 +186,7 @@ def _check_primary_key(resource: PropertyField) -> list[Issue]:
             message=(
                 f"No fields found in resource for primary key fields: {unknown_fields}."
             ),
+            instance=pk_fields,
         )
     ]
 

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -129,7 +129,7 @@ def check(
         _set_should_fields_to_required(schema)
 
     issues = _check_object_against_json_schema(properties, schema)
-    issues += _check_keys(properties, _map(issues, lambda issue: issue.jsonpath))
+    issues += _check_keys(properties, issues)
     issues += apply_extensions(properties, config.extensions)
     issues = exclude(issues, config.exclusions, properties)
     issues = sorted(set(issues))
@@ -140,15 +140,15 @@ def check(
     return issues
 
 
-def _check_keys(properties: dict[str, Any], issue_jsonpaths: list[str]) -> list[Issue]:
+def _check_keys(properties: dict[str, Any], issues: list[Issue]) -> list[Issue]:
     """Check that primary and foreign keys exist."""
     # Primary keys
     resources_with_pk = _get_fields_at_jsonpath(
         "$.resources[?(length(@.schema.primaryKey) > 0 || @.schema.primaryKey == '')]",
         properties,
     )
-    resources_with_pk = _only_resources_with_correct_property_at(
-        "schema.primaryKey", resources_with_pk, issue_jsonpaths
+    resources_with_pk = _keep_resources_with_no_issue_at_property(
+        resources_with_pk, issues, "schema.primaryKey"
     )
     issues = _flat_map(resources_with_pk, _check_primary_key)
 
@@ -157,16 +157,22 @@ def _check_keys(properties: dict[str, Any], issue_jsonpaths: list[str]) -> list[
     return issues
 
 
-def _only_resources_with_correct_property_at(
-    jsonpath: str, resources: list[PropertyField], issue_jsonpaths: list[str]
+def _issues_at_property(
+    resource: PropertyField, issues: list[Issue], jsonpath: str
+) -> list[Issue]:
+    return _filter(
+        issues,
+        lambda issue: f"{resource.jsonpath}.{jsonpath}" in issue.jsonpath,
+    )
+
+
+def _keep_resources_with_no_issue_at_property(
+    resources: list[PropertyField], issues: list[Issue], jsonpath: str
 ) -> list[PropertyField]:
-    """Filter out resources that have an error at or under the given `jsonpath`."""
+    """Filter out resources that have an issue at or under the given `jsonpath`."""
     return _filter(
         resources,
-        lambda resource: not _filter(
-            issue_jsonpaths,
-            lambda path: f"{resource.jsonpath}.{jsonpath}" in path,
-        ),
+        lambda resource: not _issues_at_property(resource, issues, jsonpath),
     )
 
 

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -3,8 +3,9 @@ import sys
 from dataclasses import dataclass, field
 from functools import reduce
 from types import TracebackType
-from typing import Any, Callable, Iterator, Optional
+from typing import Any, Callable, Iterator, Optional, cast
 
+from jsonpath import findall, resolve
 from jsonschema import Draft7Validator, FormatChecker, ValidationError
 
 from check_datapackage.config import Config
@@ -16,8 +17,10 @@ from check_datapackage.constants import (
 from check_datapackage.exclusion import exclude
 from check_datapackage.extensions import apply_extensions
 from check_datapackage.internals import (
+    PropertyField,
     _filter,
     _flat_map,
+    _get_fields_at_jsonpath,
     _map,
 )
 from check_datapackage.issue import Issue
@@ -87,6 +90,7 @@ def check(
         _set_should_fields_to_required(schema)
 
     issues = _check_object_against_json_schema(properties, schema)
+    issues += _check_keys(properties, _map(issues, lambda issue: issue.jsonpath))
     issues += apply_extensions(properties, config.extensions)
     issues = exclude(issues, config.exclusions, properties)
     issues = sorted(set(issues))
@@ -95,6 +99,78 @@ def check(
         raise DataPackageError(issues)
 
     return issues
+
+
+def _check_keys(properties: dict[str, Any], issue_jsonpaths: list[str]) -> list[Issue]:
+    """Check that primary and foreign keys exist."""
+    # Primary keys
+    resources_with_pk = _get_fields_at_jsonpath(
+        "$.resources[?(length(@.schema.primaryKey) > 0 || @.schema.primaryKey == '')]",
+        properties,
+    )
+    resources_with_pk = _only_resources_with_correct_property_at(
+        "schema.primaryKey", resources_with_pk, issue_jsonpaths
+    )
+    issues = _flat_map(resources_with_pk, _check_primary_key)
+
+    # Foreign keys
+
+    return issues
+
+
+def _only_resources_with_correct_property_at(
+    jsonpath: str, resources: list[PropertyField], issue_jsonpaths: list[str]
+) -> list[PropertyField]:
+    """Filter out resources that have an error at or under the given `jsonpath`."""
+    return _filter(
+        resources,
+        lambda resource: not _filter(
+            issue_jsonpaths,
+            lambda path: f"{resource.jsonpath}.{jsonpath}" in path,
+        ),
+    )
+
+
+def _check_primary_key(resource: PropertyField) -> list[Issue]:
+    """Check that primary key fields exist in the resource."""
+    pk_fields = _key_fields_as_str_list(resolve("/schema/primaryKey", resource.value))
+    unknown_fields = _get_unknown_key_fields(pk_fields, resource.value)
+
+    if not unknown_fields:
+        return []
+
+    return [
+        Issue(
+            jsonpath=f"{resource.jsonpath}.schema.primaryKey",
+            type="primary-key",
+            message=(
+                f"No fields found in resource for primary key fields: {unknown_fields}."
+            ),
+        )
+    ]
+
+
+def _key_fields_as_str_list(key_fields: Any) -> list[str]:
+    """Returns the list representation of primary and foreign key fields.
+
+    Key fields can be represented either as a string (containing one field name)
+    or a list of strings.
+
+    The input should contain a correctly typed `key_fields` object.
+    """
+    if not isinstance(key_fields, list):
+        key_fields = [key_fields]
+    return cast(list[str], key_fields)
+
+
+def _get_unknown_key_fields(
+    key_fields: list[str], properties: dict[str, Any], resource_path: str = ""
+) -> str:
+    """Return the key fields that don't exist on the specified resource."""
+    known_fields = findall(f"{resource_path}schema.fields[*].name", properties)
+    unknown_fields = _filter(key_fields, lambda field: field not in known_fields)
+    unknown_fields = _map(unknown_fields, lambda field: f"'{field}'")
+    return ", ".join(unknown_fields)
 
 
 def _set_should_fields_to_required(schema: dict[str, Any]) -> dict[str, Any]:

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -208,7 +208,7 @@ def _get_unknown_key_fields(
     """Return the key fields that don't exist on the specified resource."""
     known_fields = findall(f"{resource_path}schema.fields[*].name", properties)
     unknown_fields = _filter(key_fields, lambda field: field not in known_fields)
-    unknown_fields = _map(unknown_fields, lambda field: f"'{field}'")
+    unknown_fields = _map(unknown_fields, lambda field: f"{field!r}")
     return ", ".join(unknown_fields)
 
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -117,6 +117,7 @@ def test_fail_primary_key_with_unknown_fields(primary_key):
     assert len(issues) == 1
     assert issues[0].jsonpath == "$.resources[0].schema.primaryKey"
     assert issues[0].type == "primary-key"
+    assert issues[0].instance == primary_key
 
 
 @mark.parametrize("primary_key", [None, 123, [], [123, "a_field"]])


### PR DESCRIPTION
# Description

This PR implements the MUST constraint that primary key fields must exist (i.e. they must be fields on the same resource).

Closes #216 

Needs an in-depth review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
