### PR TITLE
feat: :sparkles: check foreign keys fields exist

### DIFF
--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -221,7 +221,7 @@ def _get_unknown_key_fields(
     """Return the key fields that don't exist on the specified resource."""
     known_fields = findall(f"{resource_path}schema.fields[*].name", properties)
     unknown_fields = _filter(key_fields, lambda field: field not in known_fields)
-    unknown_fields = _map(unknown_fields, lambda field: f"'{field}'")
+    unknown_fields = _map(unknown_fields, lambda field: f"{field!r}")
     return ", ".join(unknown_fields)
 
 

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -274,7 +274,7 @@ def _check_fk_dest_fields_same_resource(
             jsonpath=f"{resource.jsonpath}.schema.foreignKeys.reference.fields",
             type="foreign-key-destination-fields",
             message=(
-                f"No fields found in resource for foreign key "
+                "No fields found in resource for foreign key "
                 f"destination fields: {unknown_fields}."
             ),
         )
@@ -297,7 +297,7 @@ def _check_fk_dest_fields_diff_resource(
                 type="foreign-key-destination-resource",
                 message=(
                     f"The destination resource '{dest_resource_name}' of this foreign "
-                    f"key doesn't exist in the package."
+                    "key doesn't exist in the package."
                 ),
             )
         ]

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -296,7 +296,7 @@ def _check_fk_dest_fields_diff_resource(
                 jsonpath=f"{resource.jsonpath}.schema.foreignKeys.reference.resource",
                 type="foreign-key-destination-resource",
                 message=(
-                    f"The destination resource '{dest_resource_name}' of this foreign "
+                    f"The destination resource {dest_resource_name!r} of this foreign "
                     "key doesn't exist in the package."
                 ),
             )
@@ -313,7 +313,7 @@ def _check_fk_dest_fields_diff_resource(
             jsonpath=f"{resource.jsonpath}.schema.foreignKeys.reference.fields",
             type="foreign-key-destination-fields",
             message=(
-                f"No fields found in destination resource '{dest_resource_name}' "
+                f"No fields found in destination resource {dest_resource_name!r} "
                 f"for foreign key destination fields: {unknown_fields}."
             ),
         )

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -178,6 +178,7 @@ def test_fail_mismatched_foreign_key_fields():
     assert len(issues) == 1
     assert issues[0].jsonpath == "$.resources[0].schema.foreignKeys.fields"
     assert issues[0].type == "foreign-key-source-fields"
+    assert issues[0].instance == ["known_field"]
 
 
 @mark.parametrize(
@@ -205,6 +206,7 @@ def test_fail_bad_foreign_key_source_fields(source_fields, dest_fields):
     assert len(issues) == 1
     assert issues[0].jsonpath == "$.resources[0].schema.foreignKeys.fields"
     assert issues[0].type == "foreign-key-source-fields"
+    assert issues[0].instance == source_fields
 
 
 @mark.parametrize(
@@ -234,6 +236,7 @@ def test_fail_bad_foreign_key_destination_fields_same_resource(
     assert len(issues) == 1
     assert issues[0].jsonpath == "$.resources[0].schema.foreignKeys.reference.fields"
     assert issues[0].type == "foreign-key-destination-fields"
+    assert issues[0].instance == dest_fields
 
 
 def test_do_not_check_bad_foreign_keys_against_fields_same_resource():
@@ -288,6 +291,7 @@ def test_fail_foreign_key_with_unknown_destination_resource(properties_fk):
     assert len(issues) == 1
     assert issues[0].jsonpath == "$.resources[0].schema.foreignKeys.reference.resource"
     assert issues[0].type == "foreign-key-destination-resource"
+    assert issues[0].instance == "unknown"
 
 
 @mark.parametrize(
@@ -313,6 +317,7 @@ def test_fail_bad_foreign_key_destination_fields_different_resource(
     assert len(issues) == 1
     assert issues[0].jsonpath == "$.resources[0].schema.foreignKeys.reference.fields"
     assert issues[0].type == "foreign-key-destination-fields"
+    assert issues[0].instance == dest_fields
 
 
 def test_do_not_check_bad_foreign_keys_against_fields_different_resource(properties_fk):


### PR DESCRIPTION
# Description

This PR checks that foreign key source and destination fields exist.
#218 should be reviewed first.

Closes #217 

Needs an in-depth review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
