### PR TITLE
feat: :sparkles: display helpful error message for empty input

### DIFF
--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -93,14 +93,19 @@ def _create_explanation(issue: Issue) -> str:
     """Create an informative explanation of what went wrong in each issue."""
     # Remove suffix '$' to account for root path when `[]` is passed to `check()`
     property_name = issue.jsonpath.removesuffix("$").split(".")[-1]
-    number_of_carets = len(str(issue.instance))
-    return (  # noqa: F401
-        f"At package{issue.jsonpath.removeprefix('$')}:\n"
-        "|\n"
-        f"| {property_name}{': ' if property_name else '  '}{issue.instance}\n"
-        f"| {' ' * len(property_name)}  {'^' * number_of_carets}\n"
-        f"{issue.message}\n"
-    )
+    if property_name:
+        number_of_carets = len(str(issue.instance))
+        return (  # noqa: F401
+            f"At package{issue.jsonpath.removeprefix('$')}:\n"
+            "|\n"
+            f"| {property_name}{': ' if property_name else '  '}{issue.instance}\n"
+            f"| {' ' * len(property_name)}  {'^' * number_of_carets}\n"
+            f"{issue.message}\n"
+        )
+    else:
+        return (
+            "`check()` requires a dictionary with metadata, but received an empty list."
+        )
 
 
 def check(

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -104,7 +104,8 @@ def _create_explanation(issue: Issue) -> str:
         )
     else:
         return (
-            "`check()` requires a dictionary with metadata, but received an empty list."
+            "check() requires a dictionary with metadata,"
+            f" but received {issue.instance}."
         )
 
 

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -93,20 +93,20 @@ def _create_explanation(issue: Issue) -> str:
     """Create an informative explanation of what went wrong in each issue."""
     # Remove suffix '$' to account for root path when `[]` is passed to `check()`
     property_name = issue.jsonpath.removesuffix("$").split(".")[-1]
-    if property_name:
-        number_of_carets = len(str(issue.instance))
-        return (  # noqa: F401
-            f"At package{issue.jsonpath.removeprefix('$')}:\n"
-            "|\n"
-            f"| {property_name}{': ' if property_name else '  '}{issue.instance}\n"
-            f"| {' ' * len(property_name)}  {'^' * number_of_carets}\n"
-            f"{issue.message}\n"
-        )
-    else:
+    if not property_name:
         return (
             "check() requires a dictionary with metadata,"
             f" but received {issue.instance}."
         )
+
+    number_of_carets = len(str(issue.instance))
+    return (  # noqa: F401
+        f"At package{issue.jsonpath.removeprefix('$')}:\n"
+        "|\n"
+        f"| {property_name}{': ' if property_name else '  '}{issue.instance}\n"
+        f"| {' ' * len(property_name)}  {'^' * number_of_carets}\n"
+        f"{issue.message}\n"
+    )
 
 
 def check(

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from pytest import fixture, mark, raises
 
-from check_datapackage.check import DataPackageError, check
+from check_datapackage.check import DataPackageError, check, explain
 from check_datapackage.config import Config
 from check_datapackage.constants import FIELD_TYPES
 from check_datapackage.examples import (
@@ -490,6 +490,31 @@ def test_exclusion_does_exclude_custom_check():
     issues = check(properties, config=config)
 
     assert issues == []
+
+
+# Issues at $.
+
+
+@mark.parametrize(
+    "properties",
+    [
+        (""),
+        ("abc"),
+        (123),
+        ([]),
+        ([123]),
+        (()),
+        (("abc",)),
+        (True),
+        (None),
+    ],
+)
+def test_correct_explain_output_for_invalid_objects(properties):
+    issues = check(properties)
+    error_msg = (
+        f"check() requires a dictionary with metadata, but received {properties}."
+    )
+    assert explain(issues).split("\n")[-1] == error_msg
 
 
 # Issues at $.resources[x]

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -497,17 +497,7 @@ def test_exclusion_does_exclude_custom_check():
 
 @mark.parametrize(
     "properties",
-    [
-        (""),
-        ("abc"),
-        (123),
-        ([]),
-        ([123]),
-        (()),
-        (("abc",)),
-        (True),
-        (None),
-    ],
+    ["", "abc", 123, [], [123], (), ("abc",), True, None],
 )
 def test_correct_explain_output_for_invalid_objects(properties):
     issues = check(properties)


### PR DESCRIPTION
# Description

Currently the output when an empty list is passed to `check` is not that helpful. I'm sure the error message can be improved further, but this is just to get the ball rolling since there is synergy with #241 

```sh
uv run python -c 'import check_datapackage as cdp; cdp.check([], error=True)'              
```

Output before this PR (after merging #241):

```  
1 issue was found in your `datapackage.json`:

At :
|
|   []
|   ^^
[] is not of type 'object'
```

Output after this PR:

```
`check()` requires a dictionary with metadata, but received an empty list.
```
Closes https://github.com/seedcase-project/check-datapackage/issues/220

Needs a quick review.

## Checklist

- [ ] Formatted Markdown
- [x] Ran `just run-all`
