### PR TITLE
fix: :bug: no traceback and correct rich formatting in IPython

### DIFF
--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -85,7 +85,7 @@ def explain(issues: list[Issue]) -> str:
     num_issues = len(issue_explanations)
     singular_or_plural = " was" if num_issues == 1 else "s were"
     return (
-        f"{num_issues} issue{singular_or_plural} found in your [u]datapackage.json[/u]:\n\n"
+        f"{num_issues} issue{singular_or_plural} found in your [u]datapackage.json[/u]:\n\n"  # noqa: E501
         + "\n".join(issue_explanations)
     )
 

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -51,10 +51,20 @@ def no_traceback_hook(
 # Need to use a custom exception hook to hide tracebacks for our custom exceptions
 sys.excepthook = no_traceback_hook
 
+
 # Unfortunately, IPython uses its own exception handling mechanism,
 # so we need to set a separate custom exception handler there.
-try:
-    import IPython
+def _is_running_from_ipython() -> bool:
+    """Checks whether running in IPython interactive console or not."""
+    try:
+        from IPython import get_ipython  # type: ignore[attr-defined]
+    except ImportError:
+        return False
+    else:
+        return get_ipython() is not None  # type: ignore[no-untyped-call]
+
+
+if _is_running_from_ipython():
 
     def no_traceback_in_ipython(
         self: Any,
@@ -72,9 +82,7 @@ try:
                 (exc_type, exc_value, exc_traceback), tb_offset=tb_offset
             )
 
-    IPython.get_ipython().set_custom_exc((Exception,), no_traceback_in_ipython)  # type: ignore
-except ImportError:
-    pass
+    get_ipython().set_custom_exc((Exception,), no_traceback_in_ipython)  # type: ignore  # noqa: F821
 
 
 class DataPackageError(Exception):

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -28,6 +28,14 @@ from check_datapackage.issue import Issue
 from check_datapackage.read_json import read_json
 
 
+def _pretty_print_exception(
+    exc_type: type[BaseException],
+    exc_value: BaseException,
+) -> None:
+    # Print the error type and message, without traceback
+    return rprint(f"\n[red]{exc_type.__name__}[/red]: {exc_value}")
+
+
 def no_traceback_hook(
     exc_type: type[BaseException],
     exc_value: BaseException,
@@ -35,8 +43,7 @@ def no_traceback_hook(
 ) -> None:
     """Exception hook to hide tracebacks for DataPackageError."""
     if issubclass(exc_type, DataPackageError):
-        # Only print the message, without traceback
-        rprint(f"\n[red]{exc_type.__name__}[/red]: {exc_value}")
+        _pretty_print_exception(exc_type, exc_value)
     else:
         sys.__excepthook__(exc_type, exc_value, exc_traceback)
 
@@ -57,7 +64,13 @@ try:
         tb_offset: None = None,
     ) -> None:
         """Hide tracebacks and correctly display rich markup in IPython."""
-        no_traceback_hook(exc_type, exc_value, exc_traceback)
+        if issubclass(exc_type, DataPackageError):
+            _pretty_print_exception(exc_type, exc_value)
+        else:
+            # Regular IPython traceback
+            self.showtraceback(
+                (exc_type, exc_value, exc_traceback), tb_offset=tb_offset
+            )
 
     IPython.get_ipython().set_custom_exc((Exception,), no_traceback_in_ipython)  # type: ignore
 except ImportError:

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Iterator, Optional, cast
 
 from jsonpath import findall, resolve
 from jsonschema import Draft7Validator, FormatChecker, ValidationError
+from rich import print as rprint
 
 from check_datapackage.config import Config
 from check_datapackage.constants import (
@@ -35,7 +36,7 @@ def no_traceback_hook(
     """Exception hook to hide tracebacks for DataPackageError."""
     if issubclass(exc_type, DataPackageError):
         # Only print the message, without traceback
-        print("{0}".format(exc_value))
+        rprint(f"{exc_value}")
     else:
         sys.__excepthook__(exc_type, exc_value, exc_traceback)
 
@@ -84,7 +85,7 @@ def explain(issues: list[Issue]) -> str:
     num_issues = len(issue_explanations)
     singular_or_plural = " was" if num_issues == 1 else "s were"
     return (
-        f"{num_issues} issue{singular_or_plural} found in your `datapackage.json`:\n\n"
+        f"{num_issues} issue{singular_or_plural} found in your [u]datapackage.json[/u]:\n\n"
         + "\n".join(issue_explanations)
     )
 

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -36,7 +36,7 @@ def no_traceback_hook(
     """Exception hook to hide tracebacks for DataPackageError."""
     if issubclass(exc_type, DataPackageError):
         # Only print the message, without traceback
-        rprint(f"{exc_value}")
+        rprint(f"{exc_type.__name__}: {exc_value}")
     else:
         sys.__excepthook__(exc_type, exc_value, exc_traceback)
 

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -36,7 +36,7 @@ def no_traceback_hook(
     """Exception hook to hide tracebacks for DataPackageError."""
     if issubclass(exc_type, DataPackageError):
         # Only print the message, without traceback
-        rprint(f"{exc_type.__name__}: {exc_value}")
+        rprint(f"\n[red]{exc_type.__name__}[/red]: {exc_value}")
     else:
         sys.__excepthook__(exc_type, exc_value, exc_traceback)
 
@@ -99,7 +99,7 @@ def _create_explanation(issue: Issue) -> str:
         f"At package{issue.jsonpath.removeprefix('$')}:\n"
         "|\n"
         f"| {property_name}{': ' if property_name else '  '}{issue.instance}\n"
-        f"| {' ' * len(property_name)}  {'^' * number_of_carets}\n"
+        f"| {' ' * len(property_name)}  [red]{'^' * number_of_carets}[/red]\n"
         f"{issue.message}\n"
     )
 

--- a/src/check_datapackage/check.py
+++ b/src/check_datapackage/check.py
@@ -44,6 +44,25 @@ def no_traceback_hook(
 # Need to use a custom exception hook to hide tracebacks for our custom exceptions
 sys.excepthook = no_traceback_hook
 
+# Unfortunately, IPython uses its own exception handling mechanism,
+# so we need to set a separate custom exception handler there.
+try:
+    import IPython
+
+    def no_traceback_in_ipython(
+        self: Any,
+        exc_type: type[BaseException],
+        exc_value: BaseException,
+        exc_traceback: TracebackType | None,
+        tb_offset: None = None,
+    ) -> None:
+        """Hide tracebacks and correctly display rich markup in IPython."""
+        no_traceback_hook(exc_type, exc_value, exc_traceback)
+
+    IPython.get_ipython().set_custom_exc((Exception,), no_traceback_in_ipython)  # type: ignore
+except ImportError:
+    pass
+
 
 class DataPackageError(Exception):
     """Convert Data Package issues to an error and hide the traceback."""


### PR DESCRIPTION
*Rebase and merge after #244 and #246*

# Description

IPython has its own exception handler and does not respect `sys.excepthook`. The solution here is based on [this SO answer](https://stackoverflow.com/a/70433500/2166823) and [this code snippet](https://gist.github.com/waszil/fccda8749ed5dd5baa336bae8e88dd7a). Note that [the IPython docs](https://ipython.readthedocs.io/en/stable/api/generated/IPython.core.interactiveshell.html#IPython.core.interactiveshell.InteractiveShell.set_custom_exc) include a warning about modifying the traceback (I don't know if there is actually any additional risk from modifying the system traceback as we are currently doing):

> WARNING: by putting in your own exception handler into IPython’s main execution loop, you run a very good chance of nasty crashes. This facility should only be used if you really know what you are doing.

Test in IPython/Jupyter with:

```py
import check_datapackage as cdp; cdp.check(123, error=True)
```

### Output before this PR:
<img width="770" height="342" alt="image" src="https://github.com/user-attachments/assets/7079ac1d-0a91-4291-b67e-88be05e2a40d" />


### Output after this PR:
<img width="771" height="185" alt="image" src="https://github.com/user-attachments/assets/7babf921-ea89-42ec-a044-dc787b8f08aa" />


### Docs before this PR:
<img width="604" height="685" alt="image" src="https://github.com/user-attachments/assets/48079b14-5313-41e6-8462-524d3bc7481b" />

### Docs after this PR:
<img width="606" height="420" alt="image" src="https://github.com/user-attachments/assets/e26ba9ee-8881-4e49-9d61-83268bdcc5a8" />


Closes #248, closes seedcase-project/seedcase-sprout#1608

---

Needs an in-depth review.

## Checklist

- [ ] Formatted Markdown
- [x] Ran `just run-all`
