### PR TITLE
docs: :memo: use "properties" instead of "descriptor" in docs

### DIFF
--- a/docs/design/architecture.qmd
+++ b/docs/design/architecture.qmd
@@ -53,7 +53,7 @@ used throughout the package can be found in the tables below.
 |----------------------------|--------------------------------------------|
 | check | Check that properties comply with the Data Package standard. |
 | explain | Explain issues flagged by the check action in more detail using non-technical language. |
-| read | Read various files, such as a Data Package descriptor or a configuration file. |
+| read | Read various files, such as a Data Package descriptor (the properties) or a configuration file. |
 
 : Actions that `check-datapackage` can perform.
 
@@ -115,7 +115,7 @@ the first edition to ensure backward compatibility.
 :::
 
 The users, described in the [User types](#user-types) section, provide
-`check-datapackage` with their Data Package's descriptor to check its
+`check-datapackage` with their Data Package's properties to check its
 compliance with the standard.
 
 ```{mermaid}
@@ -134,7 +134,7 @@ flowchart LR
 
 
     dp_standard --"Definition of the standard"--> check
-    Users --"Check Data Package<br>descriptor"--> check
+    Users --"Check Data Package<br>properties"--> check
     %% Styling
     style Users fill:#FFFFFF, color:#000000
 ```
@@ -169,8 +169,8 @@ flowchart LR
     end
 
     dp_standard --"Definition of the standard"--> python
-    users --"Check Data Package<br>descriptor programmatically"--> python
-    users -. "Check Data Package<br>descriptor via the CLI" .-> cli
+    users --"Check Data Package<br>properties programmatically"--> python
+    users -. "Check Data Package<br>properties via the CLI" .-> cli
 
     %% Styling
     style check-datapackage fill:#FFFFFF, color:#000000

--- a/src/check_datapackage/config.py
+++ b/src/check_datapackage/config.py
@@ -7,7 +7,7 @@ from check_datapackage.extensions import Extensions
 
 
 class Config(BaseModel, frozen=True):
-    """Configuration for checking a Data Package descriptor.
+    """Configuration for checking a Data Package's properties.
 
     Attributes:
         exclusions (list[Exclusion]): Any issues matching any of Exclusion objects will

--- a/src/check_datapackage/issue.py
+++ b/src/check_datapackage/issue.py
@@ -4,9 +4,9 @@ from typing import Any
 
 @dataclass(order=True, frozen=True)
 class Issue:
-    """An issue found while checking a Data Package descriptor.
+    """An issue found while checking a Data Package's properties.
 
-    One `Issue` object represents one failed check on one field within the descriptor.
+    One `Issue` object represents one failed check on one field within the properties.
 
     Attributes:
         jsonpath (string): A [JSON path](https://jg-rp.github.io/python-jsonpath/syntax/)

--- a/tests/test_read_json.py
+++ b/tests/test_read_json.py
@@ -10,8 +10,8 @@ def test_reads(tmp_path: Path) -> None:
     """Correctly reads a JSON file into a dictionary."""
     json_path = tmp_path / "datapackage.json"
     json_path.write_text('{"name": "example", "resources": []}')
-    descriptor = read_json(json_path)
-    assert descriptor == {"name": "example", "resources": []}
+    properties = read_json(json_path)
+    assert properties == {"name": "example", "resources": []}
 
 
 def test_not_a_dict(tmp_path: Path) -> None:


### PR DESCRIPTION
# Description

There were a few leftover uses of "descriptor", so this fixes that.

Needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
