### PR TITLE
docs: :memo: uncomment `check()` call in example docs

### DIFF
--- a/src/check_datapackage/extensions.py
+++ b/src/check_datapackage/extensions.py
@@ -51,7 +51,7 @@ class CustomCheck(BaseModel, frozen=True):
                 custom_checks=[license_check]
             )
         )
-        # check(descriptor, config=config)
+        cdp.check(cdp.example_package_properties(), config=config)
         ```
     """
 


### PR DESCRIPTION
# Description

Simple fix, just uncomment use of `check()`.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
