### PR TITLE
docs: :lipstick: use `rich` for pretty output in guide docs

### DIFF
--- a/docs/guide/check.qmd
+++ b/docs/guide/check.qmd
@@ -5,6 +5,8 @@ jupyter: python3
 order: 1
 ---
 
+{{< include ../includes/_pretty_repr.qmd >}}
+
 The purpose of `check-datapackage` is to make sure a Data Package's
 metadata---stored in its `datapackage.json` file---complies with the
 [Data Package standard](https://datapackage.org). This standard defines
@@ -48,11 +50,9 @@ format. The example looks like this (from the
 
 ```{python}
 import check_datapackage as cdp
-import pprint
-
 
 package_properties = cdp.example_package_properties()
-pprint.pp(package_properties)
+package_properties
 ```
 
 When we call `check()` on these properties, it returns an empty list:

--- a/docs/guide/config.qmd
+++ b/docs/guide/config.qmd
@@ -5,6 +5,8 @@ jupyter: python3
 order: 3
 ---
 
+{{< include ../includes/_pretty_repr.qmd >}}
+
 You can pass a [`Config`](/docs/reference/Config.qmd) object to
 [`check()`](/docs/reference/check.qmd) to customise the checks done on
 your Data Package's properties. The following configuration options are
@@ -40,7 +42,6 @@ the `required` check by defining an `Exclusion` object with this `type`:
 
 ```{python}
 from textwrap import dedent
-import pprint
 import check_datapackage as cdp
 
 exclusion_required = cdp.Exclusion(type="required")
@@ -90,7 +91,7 @@ package_properties = cdp.example_package_properties()
 package_properties["name"] = 123
 package_properties["created"] = "not-a-date"
 package_properties["resources"][0]["path"] = "\\not/a/path"
-pprint.pp(package_properties)
+package_properties
 ```
 
 When we run `check()` on these properties, we get the three expected issues:

--- a/docs/guide/issues.qmd
+++ b/docs/guide/issues.qmd
@@ -5,6 +5,8 @@ jupyter: python3
 order: 2
 ---
 
+{{< include ../includes/_pretty_repr.qmd >}}
+
 ## The `Issue` class
 
 One `Issue` corresponds to one failed check on one field in the

--- a/docs/includes/_pretty_repr.qmd
+++ b/docs/includes/_pretty_repr.qmd
@@ -1,0 +1,8 @@
+<!-- Make output representation of code objects easier to read-->
+
+```{python}
+#| include: false
+from rich import pretty
+
+pretty.install()
+```


### PR DESCRIPTION
# Description

Needs a quick review
Closes #238

Make output easier to read, esp larger objects like dictionaries. This adds both coloring and formatting. See commit messages for more details.

Currently, output like multiple issues is a mess and hard to read:
<img width="765" height="281" alt="image" src="https://github.com/user-attachments/assets/b9bb724c-1bb9-441a-b961-766955a0966a" />

After this PR the structure is much better (the default colors are a bit off for a light bg; will be dealt with in a follow up PR:
<img width="765" height="518" alt="image" src="https://github.com/user-attachments/assets/d4520998-9cf2-4c70-a781-0539c86943a4" />



Before (soft-wrapping and no color):
<img width="772" height="477" alt="Screenshot from 2025-12-18 08-31-25" src="https://github.com/user-attachments/assets/1ee81785-003d-4fd7-88cd-540ecd22b7ba" />

After (no wrapping and color):
<img width="773" height="483" alt="Screenshot from 2025-12-18 08-30-58" src="https://github.com/user-attachments/assets/ae4a9710-bc3e-4a92-97b0-12997691b497" />

Sometimes the lack of wrapping becomes a bit of an issue, but this will be dealt with in a follow up PR.

Before:
<img width="773" height="163" alt="Screenshot from 2025-12-18 08-21-27" src="https://github.com/user-attachments/assets/9f9a088d-871f-48e6-a6dc-4fa39aa7f4ce" />

After (would be nice if his wrapped or was spaced out more (in follow up PR):
<img width="773" height="163" alt="Screenshot from 2025-12-18 08-21-33" src="https://github.com/user-attachments/assets/3c828748-80b5-408e-8703-4caade6ceac7" />


Note that using the `__repr__` of the output is slightly different from pretty printing it; the differences are small and if anything I slightly prefer this approach.
<img width="777" height="1063" alt="Screenshot from 2025-12-16 18-16-02" src="https://github.com/user-attachments/assets/96e07286-4b26-4b95-bcd0-ff5e4a1587d0" />

## Checklist

- [x] Ran `just run-all`
    - I'm seeing some failure checking typos on a JS method in an HTML file, but that is probably not related to this PR... (maybe the built doc pages are not properly excluded from the typo check?)
