### PR TITLE
build: :wrench: switch to upstream rich after update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "jsonschema>=4.25.1",
     "pydantic>=2.12.3",
     "python-jsonpath>=2.0.1",
-    "rich>=14.2.0",
+    "rich>=14.3.0",
     "types-jsonschema>=4.25.1.20250822",
 ]
 
@@ -66,6 +66,3 @@ dev = [
     "typos>=1.35.6",
     "vulture>=2.14",
 ]
-
-[tool.uv.sources]
-rich = { git = "https://github.com/joelostblom/rich", rev = "ipython-console-param" }


### PR DESCRIPTION
# Description

My upstream PR was merged so we no longer have to point to the branch I made. Ref https://github.com/Textualize/rich/releases/tag/v14.3.0

Needs a quick review.

