### PR TITLE
build: 🔨 ensure docs don't pick up local config files

### DIFF
--- a/docs/guide/cli.qmd
+++ b/docs/guide/cli.qmd
@@ -24,7 +24,7 @@ check-datapackage
 
 ```{python}
 #| echo: false
-!uv run check-datapackage
+!cdp
 ```
 :::
 
@@ -48,7 +48,7 @@ Package, `flora`.
 #| echo: false
 import seedcase_soil as so
 
-!uv run check-datapackage check {so.Example.flora.path}
+!cdp check {so.Example.flora.path}
 ```
 :::
 
@@ -75,7 +75,7 @@ check-datapackage check https://raw.githubusercontent.com/seedcase-project/examp
 
 ```{python}
 #| echo: false
-!uv run check-datapackage check https://raw.githubusercontent.com/seedcase-project/example-seed-beetle/refs/heads/main/datapackage.json
+!cdp check https://raw.githubusercontent.com/seedcase-project/example-seed-beetle/refs/heads/main/datapackage.json
 ```
 :::
 
@@ -92,7 +92,7 @@ check-datapackage check gh:seedcase-project/example-seed-beetle
 
 ```{python}
 #| echo: false
-!uv run check-datapackage check gh:seedcase-project/example-seed-beetle
+!cdp check gh:seedcase-project/example-seed-beetle
 ```
 :::
 

--- a/justfile
+++ b/justfile
@@ -75,13 +75,21 @@ build-quartodoc:
     rm -rf docs/reference
     uv run quartodoc build
 
+# Run Quarto with an isolated execution directory for docs code
+_quarto-with-docs-tmpdir *args:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' EXIT
+  uv run quarto {{args}} --execute-dir "$tmpdir"
+
 # Build the documentation website using Quarto
 build-website: build-quartodoc
-    uv run quarto render --execute
+    just _quarto-with-docs-tmpdir render --execute
 
 # Preview the documentation website with automatic reload on changes
 preview-website: build-quartodoc
-  uv run quarto preview --execute
+  just _quarto-with-docs-tmpdir preview --execute
 
 # Check the commit messages on the current branch that are not on the main branch
 check-commits:
@@ -119,7 +127,7 @@ build-pdf:
   uv run quarto install tinytex
   # For generating images from Mermaid diagrams
   uv run quarto install chromium
-  uv run quarto render --profile pdf --to pdf
+  just _quarto-with-docs-tmpdir render --profile pdf --to pdf
   find docs -name "mermaid-figure-*.png" -delete
 
 # Check for unused code in the package and its tests


### PR DESCRIPTION
# Description

Sometimes when I run the docs I forget that I have a local `cdp.toml` and don't understand why the output doesn't look as expected... I think this is a more general problem that could lead to issues with sublte differences between local build and the official pages that are hard to troubleshoot. This PR ensures that the docs run in an isolated environment that is resistant to being polluted by local configs.

I found this way of doing it and if it looks good we can port to the template, but I'm open to other solutions too. Open to other ideas and if someone sees something that could go wrong here; since we moved the examples out of the dirs I don't think we rely on reading from any local paths during code execution which would have been an issue otherwise.

Needs a thorough review.

## Checklist

- [x] Ran `just run-all`
